### PR TITLE
[Feat] JWT Access token 재발급 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
 	//Oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/backend/src/main/java/peer/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/peer/backend/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
         .and()
                 .addFilter(corsConfig.corsFilter())
                 .authorizeRequests()
-                .antMatchers("/login", "/membership/**").permitAll()
+                .antMatchers("/login", "/membership/**", "/accesstoken").permitAll()
                 .anyRequest().authenticated()
 
         .and()

--- a/backend/src/main/java/peer/backend/config/jwt/TokenProvider.java
+++ b/backend/src/main/java/peer/backend/config/jwt/TokenProvider.java
@@ -35,7 +35,6 @@ public class TokenProvider {
     @Value("${jwt.token.validity-in-seconds-refresh}")
     private long refreshExpirationTime;
 
-
     public static boolean isExpired(String token, Key key) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration().before(new Date());
     }
@@ -114,5 +113,10 @@ public class TokenProvider {
             return 2;
         }
         return 0;
+    }
+
+    public boolean validateRefreshToken(String token) {
+        Key key = Keys.hmacShaKeyFor(secretKey.getBytes());
+        return isExpired(token, key);
     }
 }

--- a/backend/src/main/java/peer/backend/controller/LoginController.java
+++ b/backend/src/main/java/peer/backend/controller/LoginController.java
@@ -1,6 +1,10 @@
 package peer.backend.controller;
 
 import lombok.RequiredArgsConstructor;
+import net.bytebuddy.dynamic.scaffold.MethodGraph;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -8,13 +12,15 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import peer.backend.dto.security.Message;
+import peer.backend.dto.security.request.ToReissueTokens;
 import peer.backend.dto.security.request.UserLoginRequest;
+import peer.backend.dto.security.response.ErrorDto;
 import peer.backend.dto.security.response.JwtDto;
 import peer.backend.service.LoginService;
 
 import javax.validation.Valid;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -39,5 +45,24 @@ public class  LoginController {
     public ResponseEntity<String> userInfo(Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return new ResponseEntity<String>(userDetails.getUsername(), HttpStatus.OK);
+    }
+
+    @GetMapping("/accesstoken")
+    public ResponseEntity<Object> reissueToken(@RequestBody ToReissueTokens tokens) {
+        LinkedHashMap<String, Object> result;
+        try {
+            String token = tokens.getExpiredaccessToken();
+            Base64.Decoder decoder = Base64.getUrlDecoder();
+            String rowBody = token.split("\\.")[1];
+            String body = new String(decoder.decode(rowBody));
+            JSONParser parser = new JSONParser();
+            JSONObject jsonBody = (JSONObject)parser.parse(body);
+            Long userId = (Long)jsonBody.get("sub");
+            Message message = loginService.reissue(userId, tokens.getRefreshToken());
+            return new ResponseEntity<Object> (message.getDto(), message.getStatus());
+        } catch (ParseException e) {
+            ErrorDto errorDto = new ErrorDto("올바르지 않은 accessToken/refreshToekn입니다.", "/accesstoken");
+            return new ResponseEntity<Object> (errorDto, HttpStatus.UNAUTHORIZED);
+        }
     }
 }

--- a/backend/src/main/java/peer/backend/controller/MemberController.java
+++ b/backend/src/main/java/peer/backend/controller/MemberController.java
@@ -21,7 +21,7 @@ public class MemberController {
     private final MemberService memberService;
     private final EmailAuthService emailService;
 
-    @GetMapping("/membership/email")
+    @GetMapping("/membership/email") // 메일을 전송하기 전, DB에서 메일이 있는지 확인
     public ResponseEntity<Object> sendEmail(@Valid @RequestBody EmailAddress address) {
         Message message = emailService.sendEmail(address.getAddress());
         return new ResponseEntity<Object>(message.getStatus());
@@ -36,6 +36,6 @@ public class MemberController {
     public ResponseEntity<Object> signUp(@Valid @RequestBody UserInfo info) {
         // SQL 인젝션 체크
         Message message = memberService.signUp(info);
-        return new ResponseEntity<Object>(message.getMessage(), message.getStatus());
+        return new ResponseEntity<Object>(message.getDto(), message.getStatus());
     }
 }

--- a/backend/src/main/java/peer/backend/dto/security/Message.java
+++ b/backend/src/main/java/peer/backend/dto/security/Message.java
@@ -1,22 +1,26 @@
 package peer.backend.dto.security;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
+import peer.backend.dto.security.response.ErrorDto;
 
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Message {
     private HttpStatus status;
-    private String message;
     private Object dto;
 
-    public Message(HttpStatus status, String message) {
-        this(status, message, null);
+    public Message(HttpStatus status, String errorMessage, String errorPath) {
+        this.status = status;
+        this.dto = new ErrorDto(errorMessage, errorPath);
     }
     public Message(HttpStatus status) {
-        this(status, null, null);
+        this.status = status;
+        this.dto = null;
     }
 }

--- a/backend/src/main/java/peer/backend/dto/security/request/ToReissueTokens.java
+++ b/backend/src/main/java/peer/backend/dto/security/request/ToReissueTokens.java
@@ -1,0 +1,13 @@
+package peer.backend.dto.security.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ToReissueTokens {
+    private String expiredaccessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/peer/backend/dto/security/response/ErrorDto.java
+++ b/backend/src/main/java/peer/backend/dto/security/response/ErrorDto.java
@@ -1,0 +1,24 @@
+package peer.backend.dto.security.response;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+import java.util.Date;
+
+@Data
+public class ErrorDto {
+    private Date timestamp;
+    private Integer statusCode;
+    private String statusText;
+    private String message;
+    private String path;
+
+    public ErrorDto(String message, String path) {
+        this.timestamp = new Date();
+        this.statusCode = 401;
+        this.statusText = "Unauthorized";
+        this.message = message;
+        this.path = path;
+    }
+}

--- a/backend/src/main/java/peer/backend/repository/user/TokenRepository.java
+++ b/backend/src/main/java/peer/backend/repository/user/TokenRepository.java
@@ -1,0 +1,7 @@
+package peer.backend.repository.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import peer.backend.entity.user.RefreshToken;
+
+public interface TokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/backend/src/main/java/peer/backend/service/LoginService.java
+++ b/backend/src/main/java/peer/backend/service/LoginService.java
@@ -2,14 +2,22 @@ package peer.backend.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import peer.backend.config.jwt.TokenProvider;
+import peer.backend.dto.security.Message;
+import peer.backend.dto.security.response.ErrorDto;
 import peer.backend.dto.security.response.JwtDto;
+import peer.backend.entity.user.RefreshToken;
 import peer.backend.entity.user.User;
 import peer.backend.exception.ForbiddenException;
+import peer.backend.repository.user.TokenRepository;
 import peer.backend.repository.user.UserRepository;
+
+import java.util.HashMap;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +26,7 @@ public class LoginService {
 
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
+    private final TokenRepository tokenRepository;
     private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 
     @Transactional
@@ -35,5 +44,22 @@ public class LoginService {
                 tokenProvider.createAccessToken(user),
                 tokenProvider.createRefreshToken(user)
                 );
+    }
+
+    public Message reissue(Long userId, String refreshToken) {
+        Optional<RefreshToken> optionalToken = tokenRepository.findById(userId);
+        Optional<User> optionalUser = userRepository.findById(userId);
+        if (optionalToken.isEmpty() || optionalUser.isEmpty()) {
+            return new Message(HttpStatus.UNAUTHORIZED, "올바르지 않은 accessToken/refreshToekn입니다.", "/accesstoken");
+        }
+        RefreshToken token = optionalToken.get();
+        if (tokenProvider.validateRefreshToken(refreshToken)) {
+            return new Message(HttpStatus.UNAUTHORIZED, "refreshToken이 만료되었습니다.", "/accesstoken");
+        } else if (!refreshToken.equals(token.getRefreshToken())) {
+            return new Message(HttpStatus.UNAUTHORIZED, "올바르지 않은 accessToken/refreshToekn입니다.", "/accesstoken");
+        }
+        HashMap<String, String> result = new HashMap<>();
+        result.put("accessToken", tokenProvider.createAccessToken(optionalUser.get()));
+        return new Message(HttpStatus.OK, result);
     }
 }

--- a/backend/src/main/java/peer/backend/service/MemberService.java
+++ b/backend/src/main/java/peer/backend/service/MemberService.java
@@ -18,11 +18,11 @@ public class MemberService {
     public Message signUp(UserInfo info) {
         Optional<User> checkUser = repository.findByNickname(info.getNickname());
         if (checkUser.isPresent()) {
-            return new Message(HttpStatus.UNAUTHORIZED, "이미 존재하는 닉네임입니다.");
+            return new Message(HttpStatus.UNAUTHORIZED, "이미 존재하는 닉네임입니다.", "/signUp");
         }
         checkUser = repository.findByEmail(info.getEmail());
         if (checkUser.isPresent()) {
-            return new Message(HttpStatus.UNAUTHORIZED, "이미 존재하는 이메일입니다.");
+            return new Message(HttpStatus.UNAUTHORIZED, "이미 존재하는 이메일입니다.", "/signUp");
         }
         User user = info.convertUser();
         repository.save(user);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -59,7 +59,7 @@ spring:
 jwt:
   token:
     secret: "secretKey"
-    validity-in-seconds: 10800000
+    validity-in-seconds: 600000 #10800000
     validity-in-seconds-refresh: 604800000
 
 app:

--- a/backend/src/test/java/peer/backend/config/jwt/TokenProviderTest.java
+++ b/backend/src/test/java/peer/backend/config/jwt/TokenProviderTest.java
@@ -1,0 +1,65 @@
+package peer.backend.config.jwt;
+
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+import peer.backend.entity.user.User;
+import peer.backend.repository.user.RefreshTokenRepository;
+import peer.backend.service.UserDetailsServiceImpl;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("token provider Test")
+public class TokenProviderTest {
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private UserDetailsServiceImpl userDetailsService;
+    @InjectMocks
+    private TokenProvider tokenProvider;
+
+    @Value("${jwt.token.secret}")
+    String secretKey;
+
+    User user;
+    @BeforeEach
+    void beforeEach() {
+        user = User.builder()
+                .id(1L)
+                .user_id("asdf").name("asdf").nickname("asdf")
+                .password("asdf").email("asdf@asdf.com").birthday(LocalDateTime.now()).phone("010-1234-1234").address("asdf")
+                .is_alarm(false).certification(false)
+                .imageUrl(null).company(null).introduce(null).representAchievement(null)
+                .peerLevel(null).peerOperation(null)
+                .userPushKeywords(null).userAchievements(null).userLinks(null)
+                .build();
+    }
+
+    @Test
+    @DisplayName("create token test")
+    void createToken() {
+        String accesstoken = tokenProvider.createAccessToken(user);
+        Base64.Decoder decoder = Base64.getUrlDecoder();
+        String[] rowToken = accesstoken.split("//.");
+        String header = new String(decoder.decode(rowToken[0]));
+        String payload = new String(decoder.decode(rowToken[1]));
+        String vert = new String(decoder.decode(rowToken[2]));
+
+        System.out.printf("%s\n%s\n%s\n%n", header, payload, vert);
+    }
+}

--- a/backend/src/test/java/peer/backend/service/LoginServiceTest.java
+++ b/backend/src/test/java/peer/backend/service/LoginServiceTest.java
@@ -1,0 +1,78 @@
+package peer.backend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import peer.backend.config.jwt.TokenProvider;
+import peer.backend.dto.security.Message;
+import peer.backend.entity.user.RefreshToken;
+import peer.backend.entity.user.User;
+import peer.backend.repository.user.TokenRepository;
+import peer.backend.repository.user.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class) // @SpringbootTest와 함께 사용하면 충돌. 그리고 Moekito를 사용할 거면 SpringbootTest는 성능상 좋지 않음
+@DisplayName("login service Test")
+public class LoginServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TokenRepository tokenRepository;
+    @Mock
+    private TokenProvider tokenProvider;
+    @InjectMocks
+    private LoginService service;
+
+    Long id;
+    String refreshToken;
+    Optional<User> optionalUser;
+    Optional<RefreshToken> optionalRefreshToken;
+
+    @BeforeEach
+    void beforeEach() {
+        id = 1L;
+        refreshToken = "eyJ0eXAiOiJyZWZyZXNoVG9rZW4iLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsImlhdCI6MTY5MzgxMDc3OCwiZXhwIjoxNjk0NDE1NTc4fQ.fQ6TDUTiCa1HWc_Su00wmbbZ4wUnkpUctIesMVM3jdI";
+
+        User user = User.builder()
+                .id(id)
+                .user_id("asdf").name("asdf").nickname("asdf")
+                .password("asdf").email("asdf@asdf.com").birthday(LocalDateTime.now()).phone("010-1234-1234").address("asdf")
+                .is_alarm(false).certification(false)
+                .imageUrl(null).company(null).introduce(null).representAchievement(null)
+                .peerLevel(null).peerOperation(null)
+                .userPushKeywords(null).userAchievements(null).userLinks(null)
+                .build();
+        optionalUser = Optional.of(user);
+
+        RefreshToken token = RefreshToken.builder()
+                .userId(id)
+                .refreshToken(refreshToken)
+                .build();
+        optionalRefreshToken = Optional.of(token);
+    }
+
+    @Test
+    @DisplayName("test to reissue access token")
+    void reissueAccessToken(){
+
+        when(userRepository.findById(anyLong())).thenReturn(optionalUser);
+        when(tokenRepository.findById(anyLong())).thenReturn(optionalRefreshToken);
+        when(tokenProvider.validateRefreshToken(anyString())).thenReturn(false);
+
+        Message result = service.reissue(id, refreshToken);
+
+        assertThat(result.getStatus()).isEqualTo(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
로그인 이후, JWT Access token이 만료되었을 경우, 해당 API를 호출해 Access token을 재발급합니다.

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
![1](https://github.com/peer-42seoul/Peer-Backend/assets/76419137/390d8586-eaf9-443b-9e78-8d43949cb7fe)
* Access token을 재발급하는 sevice의 테스트 결과 입니다.

![2](https://github.com/peer-42seoul/Peer-Backend/assets/76419137/91ed3a6a-8adb-4113-b718-85de271318d3)
* Postman으로 테스트한 결과 입니다.