### PR TITLE
[FEAT]  #179 author check annotation add

### DIFF
--- a/backend/src/main/java/peer/backend/annotation/AuthorCheck.java
+++ b/backend/src/main/java/peer/backend/annotation/AuthorCheck.java
@@ -1,0 +1,11 @@
+package peer.backend.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AuthorCheck {
+}

--- a/backend/src/main/java/peer/backend/aspect/AuthorCheckAspect.java
+++ b/backend/src/main/java/peer/backend/aspect/AuthorCheckAspect.java
@@ -54,27 +54,3 @@ public class AuthorCheckAspect {
         throw new IllegalArgumentException("post_id 파라미터를 찾을 수 없습니다.");
     }
 }
-
-
-
-
-//    @Before("@annotation(peer.backend.annotation.AuthorCheck) && args(authentication, recruit_id) ")
-//    private void checkAuthor(Authentication authentication, Long recruit_id){
-//        System.out.println("gheihaiehfiaheofihaoeifh");
-//        Object[] args = joinPoint.getArgs();
-//        System.out.println(args[0]);
-//
-//        if (args.length < 2 || !(args[0] instanceof Authentication) || !(args[1] instanceof Long)) {
-//            throw new IllegalArgumentException("메서드 파라미터가 부적절합니다.");
-//        }
-//        System.out.println("gheihaiehfiaheofihaoeifh");
-//        Authentication authentication = (Authentication) args[0];
-//        Long recruit_id = (Long) args[1];
-//        Recruit recruit = recruitRepository.findById(recruit_id).orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다."));
-//        System.out.println(User.authenticationToUser(authentication).getNickname() + " " + recruit.getWriter().getNickname());
-//        if (!User.authenticationToUser(authentication).getNickname().equals(recruit.getWriter().getNickname())){
-//            System.out.println("gheihaiehfiaheofihaoeifh");
-//            throw new ForbiddenException("작성자가 아닙니다.");
-//        }
-//    }
-//}

--- a/backend/src/main/java/peer/backend/aspect/AuthorCheckAspect.java
+++ b/backend/src/main/java/peer/backend/aspect/AuthorCheckAspect.java
@@ -1,0 +1,81 @@
+package peer.backend.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import peer.backend.entity.board.recruit.Recruit;
+import peer.backend.entity.user.User;
+import peer.backend.exception.ForbiddenException;
+import peer.backend.exception.NotFoundException;
+import peer.backend.repository.board.recruit.RecruitRepository;
+import peer.backend.repository.user.UserRepository;
+
+@Aspect
+@Component
+public class AuthorCheckAspect {
+    private final RecruitRepository recruitRepository;
+
+    @Autowired
+    public AuthorCheckAspect(RecruitRepository recruitRepository){
+        this.recruitRepository = recruitRepository;
+    }
+    @Before("@annotation(peer.backend.annotation.AuthorCheck)")
+    public void checkAuthorization(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+
+        for (Object arg : args) {
+            if (arg instanceof Authentication) {
+                Authentication authentication = (Authentication) arg;
+                Long recruit_id = extractRecruitId(args); // recruit_id 추출
+
+                //recruit_id와 authentication 사용하여 사용자가 게시글 작성자인지 확인함.
+                Recruit recruit = recruitRepository.findById(recruit_id).orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다."));
+
+                String authorUsername = recruit.getWriter().getNickname();
+                String currentUsername = User.authenticationToUser(authentication).getNickname();
+
+                if (!authorUsername.equals(currentUsername)) {
+                    throw new ForbiddenException("게시글 작성자만 수정할 수 있습니다.");
+                }
+            }
+        }
+    }
+
+    private Long extractRecruitId(Object[] args) {
+        // args 배열에서 recruit_id를 추출하는 로직을 구현하세요.
+        // 예를 들어, 파라미터의 타입을 확인하여 recruit_id를 추출할 수 있습니다.
+        for (Object arg : args) {
+            if (arg instanceof Long) {
+                return (Long) arg;
+            }
+        }
+        throw new IllegalArgumentException("post_id 파라미터를 찾을 수 없습니다.");
+    }
+}
+
+
+
+
+//    @Before("@annotation(peer.backend.annotation.AuthorCheck) && args(authentication, recruit_id) ")
+//    private void checkAuthor(Authentication authentication, Long recruit_id){
+//        System.out.println("gheihaiehfiaheofihaoeifh");
+//        Object[] args = joinPoint.getArgs();
+//        System.out.println(args[0]);
+//
+//        if (args.length < 2 || !(args[0] instanceof Authentication) || !(args[1] instanceof Long)) {
+//            throw new IllegalArgumentException("메서드 파라미터가 부적절합니다.");
+//        }
+//        System.out.println("gheihaiehfiaheofihaoeifh");
+//        Authentication authentication = (Authentication) args[0];
+//        Long recruit_id = (Long) args[1];
+//        Recruit recruit = recruitRepository.findById(recruit_id).orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다."));
+//        System.out.println(User.authenticationToUser(authentication).getNickname() + " " + recruit.getWriter().getNickname());
+//        if (!User.authenticationToUser(authentication).getNickname().equals(recruit.getWriter().getNickname())){
+//            System.out.println("gheihaiehfiaheofihaoeifh");
+//            throw new ForbiddenException("작성자가 아닙니다.");
+//        }
+//    }
+//}

--- a/backend/src/main/java/peer/backend/aspect/AuthorCheckAspect.java
+++ b/backend/src/main/java/peer/backend/aspect/AuthorCheckAspect.java
@@ -32,12 +32,11 @@ public class AuthorCheckAspect {
                 Long recruit_id = extractRecruitId(args); // recruit_id 추출
 
                 //recruit_id와 authentication 사용하여 사용자가 게시글 작성자인지 확인함.
-                Recruit recruit = recruitRepository.findById(recruit_id).orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다."));
+                Recruit recruit = recruitRepository.findById(recruit_id).orElseThrow(
+                        () -> new NotFoundException("존재하지 않는 게시글입니다."));
 
-                String authorUsername = recruit.getWriter().getNickname();
-                String currentUsername = User.authenticationToUser(authentication).getNickname();
-
-                if (!authorUsername.equals(currentUsername)) {
+                if (!recruit.getWriter().getNickname()
+                        .equals(User.authenticationToUser(authentication).getNickname())) {
                     throw new ForbiddenException("게시글 작성자만 수정할 수 있습니다.");
                 }
             }

--- a/backend/src/main/java/peer/backend/controller/board/RecruitController.java
+++ b/backend/src/main/java/peer/backend/controller/board/RecruitController.java
@@ -45,7 +45,6 @@ public class RecruitController {
         recruitService.createRecruit(recruitListRequestDTO);
     }
 
-
     @ApiOperation(value = "", notes = "모집글을 업데이트 한다. 팀도 함께 업데이트 한다.")
     @PutMapping("/{recruit_id}")
     @AuthorCheck

--- a/backend/src/main/java/peer/backend/controller/board/RecruitController.java
+++ b/backend/src/main/java/peer/backend/controller/board/RecruitController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
+import peer.backend.annotation.AuthorCheck;
 import peer.backend.dto.Board.Recruit.RecruitUpdateRequestDTO;
 import peer.backend.dto.board.recruit.*;
 import peer.backend.entity.user.User;
@@ -44,8 +45,10 @@ public class RecruitController {
         recruitService.createRecruit(recruitListRequestDTO);
     }
 
+
     @ApiOperation(value = "", notes = "모집글을 업데이트 한다. 팀도 함께 업데이트 한다.")
     @PutMapping("/{recruit_id}")
+    @AuthorCheck
     public void updateRecruit(@PathVariable Long recruit_id, @RequestBody RecruitUpdateRequestDTO recruitUpdateRequestDTO, Principal principal) throws IOException {
         //TODO:principal로 권한검사
         recruitService.updateRecruit(recruit_id, recruitUpdateRequestDTO);


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
author 확인 반복작업을 위한 annotation을 추가하기 위하여

annotation 패키지에 AuthorCheck 인터페이스,
aspect 패키지에 AuthorCheckAspect 를 추가하였습니다.

aspect에서 recruitRepository를 주입하여
authentication의 유저 닉네임과 recruit의 writer_nickname을 비교하여 
일치하지 않을 경우

Forbidden 403 에러를 반환,

존재하지 않는 게시글인 경우
NotFoundException 404 에러를 반환합니다.

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
postman
