### PR TITLE
[FEAT] #185 tagList related method add

### DIFF
--- a/backend/src/main/java/peer/backend/controller/board/RecruitController.java
+++ b/backend/src/main/java/peer/backend/controller/board/RecruitController.java
@@ -1,6 +1,5 @@
 package peer.backend.controller.board;
 
-import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,6 +15,7 @@ import peer.backend.service.board.recruit.RecruitService;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,7 +46,7 @@ public class RecruitController {
 
     @ApiOperation(value = "", notes = "모집글을 업데이트 한다. 팀도 함께 업데이트 한다.")
     @PutMapping("/{recruit_id}")
-    public void updateRecruit(@PathVariable Long recruit_id, @RequestBody RecruitUpdateRequestDTO recruitUpdateRequestDTO, Principal principal) throws IOException {
+    public void updateRecruit(@PathVariable Long recruit_id, @RequestBody RecruitUpdateRequestDTO recruitUpdateRequestDTO) throws IOException {
         //TODO:principal로 권한검사
         recruitService.updateRecruit(recruit_id, recruitUpdateRequestDTO);
     }
@@ -67,4 +67,19 @@ public class RecruitController {
         User user = userRepository.findByName(principal.getName()).orElseThrow( () -> new NotFoundException("존재하지 않는 유저입니다."));
         recruitService.changeRecruitFavorite(user.getId(), recruit_id );
     }
+
+    //TODO:admin에 tag 관리 기능이 만들어지면 해당 내용 수정 필요
+    @ApiOperation(value = "", notes = "글 작성을 위한 태그리스트를 불러온다.")
+    @GetMapping("/write")
+    public List<TagListResponse> getTagListForWrite(){
+        return recruitService.getTagList();
+    }
+
+    //TODO:admin에 tag 관리 기능이 만들어지면 해당 내용 수정 필요. 추후 글 생성, 수정이 어떻게 달라질지 몰라서 일단 동일한 기능이지만 api 분리해두었음.
+    @ApiOperation(value = "", notes = "글 작성을 위한 태그리스트를 불러온다.")
+    @GetMapping("/edit")
+    public List<TagListResponse> getTagListForEdit(){
+        return recruitService.getTagList();
+    }
+
 }

--- a/backend/src/main/java/peer/backend/dto/board/recruit/TagListResponse.java
+++ b/backend/src/main/java/peer/backend/dto/board/recruit/TagListResponse.java
@@ -1,0 +1,13 @@
+package peer.backend.dto.board.recruit;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TagListResponse {
+    private String name;
+    private String color;
+}

--- a/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -1,9 +1,11 @@
 package peer.backend.service.board.recruit;
 
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
 import peer.backend.dto.Board.Recruit.RecruitUpdateRequestDTO;
 import peer.backend.dto.board.recruit.*;
 import peer.backend.dto.team.TeamApplicantListDto;
@@ -347,5 +349,14 @@ public class RecruitService {
 
         List<String> content = processMarkdownWithFormData(recruitUpdateRequestDTO.getContent());
         recruit.update(recruitUpdateRequestDTO, content);
+    }
+
+    public List<TagListResponse> getTagList(){
+        List<TagListResponse> result = new ArrayList<>();
+        result.add(new TagListResponse("Java", "#9AFE2E"));
+        result.add(new TagListResponse("JavaScript", "#045FB4"));
+        result.add(new TagListResponse("React", "#FF8000"));
+        result.add(new TagListResponse("SpringBoot", "#FE2EC8"));
+        return result;
     }
 }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
* 모집게시글 작성시 필요한 tagList를 반환합니다.
* 해당 메소드는 2스텝에서 admin에 tagList 관리 기능이 추가됐을 때 함께 수정이 필요합니다.
* getTagListForWrite와 getTagListForEdit은 기능적으로 동일하나 추후 글의 생성, 수정 기능이 달라지게 될 것을 대비하여 일단 api를 분리해 두었습니다.
* getTagListForEdit은 이전 merge가 완료되면 @AthorCheck 어노테이션으로 글작성자 여부를 검사할 예정입니다.

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
postman