### PR TITLE
[REFACTOR] Haryu specific validation update

### DIFF
--- a/backend/src/main/java/peer/backend/controller/message/MessaageController.java
+++ b/backend/src/main/java/peer/backend/controller/message/MessaageController.java
@@ -34,7 +34,7 @@ public class MessaageController {
     @ApiOperation(value = "", notes = "유저의 쪽지 목록을 불러온다.")
 //    @ApiImplicitParam(name = "id", value = "사용자 아이디", required = true, dataType = "number", paramType = "Param", defaultValue = "None")
     @GetMapping("/list")
-    public ResponseEntity<List<MsgObjectDTO>> getAllLetters(Authentication auth, @RequestParam long userId) {
+    public ResponseEntity<List<MsgObjectDTO>> getAllLetters(Authentication auth) {
         AsyncResult<List<MsgObjectDTO>> wrappedRet;
         List<MsgObjectDTO> ret;
         try {
@@ -80,8 +80,8 @@ public class MessaageController {
 //            }
 //    )
     @DeleteMapping("/delete-message")
-    public ResponseEntity<List<MsgObjectDTO>> deleteLetterList(Authentication auth, @RequestParam long userId, @RequestBody List<TargetDTO> body) {
-        this.messageMainService.deleteLetterList(userId, body);
+    public ResponseEntity<List<MsgObjectDTO>> deleteLetterList(Authentication auth, @RequestBody List<TargetDTO> body) {
+        this.messageMainService.deleteLetterList(User.authenticationToUser(auth).getId(), body);
 
         AsyncResult<List<MsgObjectDTO>> wrappedRet;
         List<MsgObjectDTO> ret;
@@ -124,7 +124,7 @@ public class MessaageController {
 
     @ApiOperation(value = "", notes = "유저가 새로운 대상에게 메시지를 처음 보냅니다.")
     @PostMapping("/new-message")
-    public ResponseEntity<List<MsgObjectDTO>> sendLetterInNewWindow(Authentication auth, @RequestParam long userId, @RequestBody MsgContentDTO body) {
+    public ResponseEntity<List<MsgObjectDTO>> sendLetterInNewWindow(Authentication auth, @RequestBody MsgContentDTO body) {
         // Message Index Create
         AsyncResult<MessageIndex> wrappedIndex;
         MessageIndex index;
@@ -166,7 +166,7 @@ public class MessaageController {
 
     @ApiOperation(value = "", notes = "유저가 특정 대상과의 대화목록을 불러옵니다.")
     @PostMapping("/conversation-list")
-    public ResponseEntity<MsgListDTO> getSpecificLetters(Authentication auth, @RequestParam long userId, @RequestBody SpecificMsgDTO body) {
+    public ResponseEntity<MsgListDTO> getSpecificLetters(Authentication auth, @RequestBody SpecificMsgDTO body) {
         AsyncResult<MsgListDTO> wrappedData;
         try {
             wrappedData = this.messageMainService.getSpecificLetterListByUserIdAndTargetId(auth, body).get();
@@ -184,7 +184,7 @@ public class MessaageController {
 
     @ApiOperation(value = "", notes = "유저가 특정 대상과의 대화목록의 과거 기록을 불러옵니다.")
     @PostMapping("/conversation-list/more")
-    public ResponseEntity<MsgListDTO> getSpecificLettersInHistory(Authentication auth, @RequestParam long userId, @RequestBody SpecificScrollMsgDTO body) {
+    public ResponseEntity<MsgListDTO> getSpecificLettersInHistory(Authentication auth, @RequestBody SpecificScrollMsgDTO body) {
         AsyncResult<MsgListDTO> wrappedData;
         try {
             wrappedData =this.messageMainService.getSpecificLetterUpByUserIdAndTargetId(auth, body).get();
@@ -202,7 +202,7 @@ public class MessaageController {
 
     @ApiOperation(value = "", notes = "유저가 특정 대상과의 대화목록에서 메시지를 전달합니다. ")
     @PostMapping("/back-message")
-    public ResponseEntity<Msg> sendBackInSpecificLetter(Authentication auth, @RequestBody MsgContentDTO body) {
+    public ResponseEntity<Msg> sendBackInSpecificLetter(Authentication auth, @RequestBody @Valid MsgContentDTO body) {
         Msg ret = this.messageMainService.sendMessage(auth, body);
         if (ret == null)
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/peer/backend/dto/message/KeywordDTO.java
+++ b/backend/src/main/java/peer/backend/dto/message/KeywordDTO.java
@@ -11,9 +11,8 @@ import javax.validation.constraints.*;
 @AllArgsConstructor
 public class KeywordDTO {
 
-    @NotEmpty(message = "문자가 없으면 검색이 되지 않습니다.")
-    @NotNull
+    @NotBlank(message = "검색할 내용을 추가하세요.")
     @Size(min=2, max=10, message = "검색 키워드는 최소 2글자, 최대 10자까지 검색이 가능합니다.")
-    @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "특수문자는 사용할 수 없습니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "키워드 검색시 특수문자는 사용하실 수 없습니다")
     private String keyword; // 대화 상대
 }

--- a/backend/src/main/java/peer/backend/dto/message/MsgContentDTO.java
+++ b/backend/src/main/java/peer/backend/dto/message/MsgContentDTO.java
@@ -3,10 +3,21 @@ package peer.backend.dto.message;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Positive;
 
 @Getter
 @NoArgsConstructor
 public class MsgContentDTO {
+    @Min(value = 0l, message = "쪽지 대상이 정확하지 않습니다.")
+    @Positive(message = "쪽지 대상이 정확하지 않습니다.")
     private long targetId;
+
+    @NotBlank(message = "빈 쪽지는 보낼수 없습니다.")
+    @Length(max = 300, message = "쪽지 허용 최대 길이를 초과하셨습니다.")
     private String content;
 }

--- a/backend/src/main/java/peer/backend/repository/user/UserRepository.java
+++ b/backend/src/main/java/peer/backend/repository/user/UserRepository.java
@@ -14,7 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findById(Long id);
 
-    @Query("SELECT m FROM User m WHERE (m.email LIKE %:keyword% OR m.nickname LIKE %:keyword%) ORDER BY m.nickname")
+    @Query("SELECT m FROM User m WHERE (m.nickname LIKE %:keyword%) ORDER BY m.nickname")
     Optional<List<User>> findByKeyWord(String keyword);
 
     Optional<List<User>> findByEmailOrNickname(String email, String nickname);


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- DTO 중 클라이언트 측에서 전달하는 데이터들의 유효성 관련하여 검사진행함
- Msg 관련하여 빈쪽지 처리, 허용길이 300자 제한, 쪽지 보낼시의 Id 지정 등을 valid annotation으로 처리함
- 쪽지 대상 검색 기능에서 이메일을 허용시 @ 와 g 같은 걸 넣으면, 불특정 다수 전체를 긁어낼 수 있는 문제 발견함.
- 이에 오로지 닉네임으로만 확인이 가능하도록 바꿈
- 특수문자 정규식으로 사용 불가능하게 지정함
- 검색 키워드는 최소 2자, 최대 10자로 제한함


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
