### PR TITLE
[FIX] ouath google redirect url 추가

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -31,6 +31,7 @@ spring:
             scope:
               - profile
               - email
+            redirect-uri: http://www.peer-test.co.kr/login/oauth2/code/google
           github:
             client-id: 6805bbb9c0e8503d21f8
             client-secret: b691ccc384cee514de82c241e1c39cacd5f457fe


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
구글 api 콘솔에는 도메인으로만 리다이렉트 URL을 입력할 수 있는데 별도의 설정을 안하면 리다이렉트 URL이 호스트 IP로 잡혀서 에러가 났습니다.
그래서 리다이렉트 URL을 명시적으로 추가해주었습니다.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
