### PR TITLE
280 hotfix 모집글 list 조회시 taglist가 content와 color로 전달될 수 있게 수정

### DIFF
--- a/backend/src/main/java/peer/backend/controller/board/RecruitController.java
+++ b/backend/src/main/java/peer/backend/controller/board/RecruitController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import peer.backend.annotation.AuthorCheck;
 import peer.backend.dto.board.recruit.*;
+import peer.backend.entity.board.recruit.Tag;
 import peer.backend.entity.user.User;
 import peer.backend.exception.NotFoundException;
 import peer.backend.repository.user.UserRepository;
@@ -72,8 +73,8 @@ public class RecruitController {
 
     //TODO:admin에 tag 관리 기능이 만들어지면 해당 내용 수정 필요
     @ApiOperation(value = "", notes = "글 작성을 위한 태그리스트를 불러온다.")
-    @GetMapping("/write")
-    public List<TagListResponse> getTagListForWrite(){
+    @GetMapping("/allTags")
+    public List<Tag> getTagListForWrite(){
         return recruitService.getTagList();
     }
 

--- a/backend/src/main/java/peer/backend/dto/board/recruit/RecruitListResponse.java
+++ b/backend/src/main/java/peer/backend/dto/board/recruit/RecruitListResponse.java
@@ -17,6 +17,6 @@ public class RecruitListResponse {
     private String user_nickname;
     private String user_thumbnail;
     private String status;
-    private List<String> tagList;
+    private List<TagListResponse> tagList;
     private boolean isFavorite;
 }

--- a/backend/src/main/java/peer/backend/dto/board/recruit/RecruitResponce.java
+++ b/backend/src/main/java/peer/backend/dto/board/recruit/RecruitResponce.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import peer.backend.entity.board.recruit.RecruitInterview;
 import peer.backend.entity.board.recruit.RecruitRole;
 import peer.backend.entity.board.recruit.enums.RecruitStatus;
+import peer.backend.entity.team.enums.TeamOperationFormat;
 import peer.backend.entity.user.enums.Role;
 
 import javax.swing.*;
@@ -22,11 +23,12 @@ public class RecruitResponce {
     private RecruitStatus status;
     private String due;
     private String content;
-    private Long leader_id;
+    private Long user_id;
     private List<String> region;
     private String link;
-    private String leader_nickname;
-    private String leader_image;
+    private String user_nickname;
+    private String user_image;
     private List<TagListResponse> tagList;
     private List<RecruitRoleDTO> roleList;
+    private TeamOperationFormat place;
 }

--- a/backend/src/main/java/peer/backend/dto/board/recruit/RecruitResponce.java
+++ b/backend/src/main/java/peer/backend/dto/board/recruit/RecruitResponce.java
@@ -27,6 +27,6 @@ public class RecruitResponce {
     private String link;
     private String leader_nickname;
     private String leader_image;
-    private List<String> tagList;
+    private List<TagListResponse> tagList;
     private List<RecruitRoleDTO> roleList;
 }

--- a/backend/src/main/java/peer/backend/entity/board/recruit/Tag.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/Tag.java
@@ -1,0 +1,13 @@
+package peer.backend.entity.board.recruit;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.persistence.Entity;
+
+@Getter
+@AllArgsConstructor
+public class Tag {
+    private String name;
+    private String color;
+}

--- a/backend/src/main/java/peer/backend/entity/board/recruit/TagListManager.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/TagListManager.java
@@ -1,0 +1,38 @@
+package peer.backend.entity.board.recruit;
+
+import org.springframework.stereotype.Component;
+import peer.backend.dto.board.recruit.TagListResponse;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class TagListManager {
+    private final List<Tag> predefinedTags = new ArrayList<>();
+
+    @PostConstruct
+    public void init() {
+        predefinedTags.add(new Tag("Java", "#9AFE2E"));
+        predefinedTags.add(new Tag("JavaScript", "#045FB4"));
+        predefinedTags.add(new Tag("React", "#FF8000"));
+        predefinedTags.add(new Tag("SpringBoot", "#FE2EC8"));
+    }
+
+    public List<Tag> getPredefinedTags() {
+        return predefinedTags;
+    }
+
+    public List<TagListResponse> getRecruitTagList(List<String> recruitTags) {
+        List<TagListResponse> result = new ArrayList<>();
+
+        for (String recruitTag : recruitTags) {
+            for (Tag tag : predefinedTags) {
+                if (recruitTag.equals(tag.getName())) {
+                    result.add(new TagListResponse(tag.getName(), tag.getColor()));
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -51,6 +51,7 @@ public class RecruitService {
     private final RecruitFavoriteRepository recruitFavoriteRepository;
     private final RecruitApplicantRepository recruitApplicantRepository;
     private final TeamUserRepository teamUserRepository;
+    private final TagListManager tagListManager;
 
     //query 생성 및 주입
     @PersistenceContext
@@ -184,7 +185,7 @@ public class RecruitService {
                         recruit2.getWriter().getNickname(),
                         recruit2.getWriter().getImageUrl(),
                         recruit2.getStatus().toString(),
-                        recruit2.getTags(),
+                        tagListManager.getRecruitTagList(recruit2.getTags()),
                         ((auth != null) &&
                                 (recruitFavoriteRepository
                                         .findById(new RecruitFavoritePK(User.authenticationToUser(auth).getId(), recruit2.getId()))
@@ -213,7 +214,7 @@ public class RecruitService {
                 .leader_id(recruit.getWriter().getId())
                 .leader_nickname(recruit.getWriter().getNickname())
                 .leader_image(recruit.getWriter().getImageUrl())
-                .tagList(recruit.getTags())
+                .tagList(tagListManager.getRecruitTagList(recruit.getTags()))
                 .roleList(roleDtoList)
                 .build();
     }
@@ -382,12 +383,7 @@ public class RecruitService {
         recruit.update(recruitUpdateRequestDTO, content);
     }
 
-    public List<TagListResponse> getTagList(){
-        List<TagListResponse> result = new ArrayList<>();
-        result.add(new TagListResponse("Java", "#9AFE2E"));
-        result.add(new TagListResponse("JavaScript", "#045FB4"));
-        result.add(new TagListResponse("React", "#FF8000"));
-        result.add(new TagListResponse("SpringBoot", "#FE2EC8"));
-        return result;
+    public List<Tag> getTagList(){
+        return tagListManager.getPredefinedTags();
     }
 }

--- a/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -211,11 +211,12 @@ public class RecruitService {
                 .totalNumber(recruit.getRoles().size())
                 .due(recruit.getDue())
                 .link(recruit.getLink())
-                .leader_id(recruit.getWriter().getId())
-                .leader_nickname(recruit.getWriter().getNickname())
-                .leader_image(recruit.getWriter().getImageUrl())
+                .user_id(recruit.getWriter().getId())
+                .user_nickname(recruit.getWriter().getNickname())
+                .user_image(recruit.getWriter().getImageUrl())
                 .tagList(tagListManager.getRecruitTagList(recruit.getTags()))
                 .roleList(roleDtoList)
+                .place(recruit.getPlace())
                 .build();
     }
 


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
TagListManager 생성, preconstruct 추가
RecruitService에서 taglist 목록 불러오는 부분 tagListManager 사용하도록 수정


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
