### PR TITLE
[HOTFIX] deleted message recovery strategy block deleted case

### DIFF
--- a/backend/src/main/java/peer/backend/controller/message/MessaageController.java
+++ b/backend/src/main/java/peer/backend/controller/message/MessaageController.java
@@ -14,12 +14,14 @@ import peer.backend.dto.asyncresult.AsyncResult;
 import peer.backend.dto.message.*;
 import peer.backend.entity.message.MessageIndex;
 import peer.backend.entity.user.User;
+import peer.backend.exception.AlreadyDeletedException;
 import peer.backend.oauth.PrincipalDetails;
 import peer.backend.service.message.MessageMainService;
 
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 
 @RestController
@@ -203,9 +205,14 @@ public class MessaageController {
     @ApiOperation(value = "", notes = "유저가 특정 대상과의 대화목록에서 메시지를 전달합니다. ")
     @PostMapping("/back-message")
     public ResponseEntity<Msg> sendBackInSpecificLetter(Authentication auth, @RequestBody @Valid MsgContentDTO body) {
-        Msg ret = this.messageMainService.sendMessage(auth, body);
-        if (ret == null)
+        Msg ret;
+        try {
+            ret = this.messageMainService.sendMessage(auth, body);
+        } catch (AlreadyDeletedException e) {
+            return new ResponseEntity<>(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
+        } catch (NoSuchElementException e) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
         return new ResponseEntity<>(ret, HttpStatus.CREATED);
     }
 }

--- a/backend/src/main/java/peer/backend/exception/AlreadyDeletedException.java
+++ b/backend/src/main/java/peer/backend/exception/AlreadyDeletedException.java
@@ -1,0 +1,5 @@
+package peer.backend.exception;
+
+public class AlreadyDeletedException extends RuntimeException{
+    public AlreadyDeletedException(String msg) { super(msg); }
+}

--- a/backend/src/main/java/peer/backend/service/message/MessageMainService.java
+++ b/backend/src/main/java/peer/backend/service/message/MessageMainService.java
@@ -23,12 +23,14 @@ import peer.backend.dto.security.Message;
 import peer.backend.entity.message.MessageIndex;
 import peer.backend.entity.message.MessagePiece;
 import peer.backend.entity.user.User;
+import peer.backend.exception.AlreadyDeletedException;
 import peer.backend.exception.NotFoundException;
 import peer.backend.repository.message.MessageIndexRepository;
 import peer.backend.repository.message.MessagePieceRepository;
 import peer.backend.repository.user.UserRepository;
 
 import javax.swing.text.html.Option;
+import java.io.IOException;
 import java.net.SocketOption;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -232,9 +234,14 @@ public class MessageMainService {
      */
 
     @Transactional(readOnly = false, propagation = Propagation.REQUIRES_NEW)
-    public Msg sendMessage(MessageIndex index, Authentication auth, MsgContentDTO message) {
+    public Msg sendMessage(MessageIndex index, Authentication auth, MsgContentDTO message) throws AlreadyDeletedException {
         User msgOwner = User.authenticationToUser(auth);
-
+        if (index.getUserIdx1().equals(msgOwner.getId())) {
+            if (index.isUser2delete())
+                throw new AlreadyDeletedException("Already user2 is delete this index.");
+        } else if (index.getUserIdx2().equals(msgOwner.getId()))
+            if (index.isUser1delete())
+                throw new AlreadyDeletedException("Already user2 is delete this index.");
         MessagePiece letter = MessagePiece.builder().
                 targetConversationId(index.getConversationId()).
                 senderNickname(msgOwner.getNickname()).
@@ -268,15 +275,6 @@ public class MessageMainService {
             return null;
         }
 
-//        String sql = "SELECT * FROM message_piece WHERE target_conversation_id = :conversationId AND msg_id < :msgId ORDER BY created_at DESC LIMIT 2";
-//        List<MessagePiece> talks = this.subService.executeNativeSQLQueryForMessagePiece(sql, Map.of("conversationId", index.getConversationId(), "msgId", rawRet.getMsgId()));
-//        boolean isEnd;
-//        if (talks.size() == 0) {
-//            isEnd = true;
-//        }
-//        else {
-//            isEnd = false;
-//        }
         Msg ret = Msg.builder().msgId(rawRet.getMsgId()).
                 end(false).
                 content(rawRet.getText()).
@@ -294,15 +292,10 @@ public class MessageMainService {
      * @return
      */
     @Transactional(readOnly = false)
-    public Msg sendMessage(Authentication auth, MsgContentDTO message) {
+    public Msg sendMessage(Authentication auth, MsgContentDTO message) throws AlreadyDeletedException {
         long targetId = message.getTargetId();
         MessageIndex index;
-        try {
-            index = this.indexRepository.findByUserIdx(User.authenticationToUser(auth).getId(), targetId).orElseThrow(() ->new NoSuchElementException("There is no talks"));
-        } catch (NoSuchElementException e)
-        {
-            return null;
-        }
+        index = this.indexRepository.findByUserIdx(User.authenticationToUser(auth).getId(), targetId).orElseThrow(() -> new NoSuchElementException("There is no talks"));
         return this.sendMessage(index, auth, message);
     }
 

--- a/backend/src/main/java/peer/backend/service/message/MessageSubService.java
+++ b/backend/src/main/java/peer/backend/service/message/MessageSubService.java
@@ -213,17 +213,6 @@ public class MessageSubService {
 
     @Transactional(readOnly = false)
     public MessageIndex saveNewData(User owner, User target) {
-//        MessageIndex newData = new MessageIndex();
-//        newData.setUserIdx1(owner.getId());
-//        newData.setUserIdx2(target.getId());
-//        newData.setUnreadMessageNumber1(0L);
-//        newData.setUnreadMessageNumber2(0L);
-//        newData.setUser1delete(false);
-//        newData.setUser2delete(false);
-//        newData.setUser1(owner);
-//        newData.setUser2(target);
-//        newData.setUser1(owner);
-//        newData.setUser2(target);
         MessageIndex newData = MessageIndex.builder().
                 userIdx1(owner.getId()).
                 userIdx2(target.getId()).

--- a/backend/src/main/java/peer/backend/service/message/MessageSubService.java
+++ b/backend/src/main/java/peer/backend/service/message/MessageSubService.java
@@ -181,8 +181,30 @@ public class MessageSubService {
         return ret;
     }
 
-    public boolean checkMessageIndexExistOrNot(long ownId, long userId) throws DataIntegrityViolationException {
+    @Transactional
+    public void recoveryMessageIndex(MessageIndex targetIndex, long who) {
+        if (who == 1) {
+            targetIndex.setUser1delete(false);
+        } else {
+            targetIndex.setUser2delete(false);
+        }
+        this.indexRepository.save(targetIndex);
+    }
+
+    public boolean checkMessageIndexExistOrNot(long ownId, long userId) throws Exception {
         Optional<MessageIndex> rawIndex = this.indexRepository.findByUserIdx(ownId, userId);
+        MessageIndex index = rawIndex.orElseThrow(() -> new Exception("Database Error is happened."));
+        if (index.getUserIdx1().equals(ownId)) {
+            if (index.isUser1delete()) {
+                this.recoveryMessageIndex(index, 1l);
+                return false;
+            }
+        } else if (index.getUserIdx2().equals(ownId)) {
+            if (index.isUser2delete()) {
+                this.recoveryMessageIndex(index, 2l);
+                return false;
+            }
+        }
         if (rawIndex.isEmpty())
             return false;
         else


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- 원래는 한 사람이 삭제를 하더라도 대화가 남고, 메시지를 보낼 수 있었음
- 이는 로직적 헛점 + 에러 상황이 발생함. -> 이에 메시지 Index 는 삭제하되, 삭제하지 않은 사람은 메시지를 받아 보는 것은 가능하게 두되, 새로운 메시지 전달이 안되도록 막아둠
- 이때 사용하는 HTTP status 는 UNAVAILABLE_FOR_LEGAL_REASONS 으로 반환하는 것으로 수정함

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
