### PR TITLE
fix: encrypt the password for the peer account

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     // Mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5' // peer 비밀번호 안전하게 저장
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/backend/src/main/java/peer/backend/config/JasyptConfig.java
+++ b/backend/src/main/java/peer/backend/config/JasyptConfig.java
@@ -1,0 +1,25 @@
+package peer.backend.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JasyptConfig {
+    @Bean(name = "jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor pbeStringEncryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig pbeConfig = new SimpleStringPBEConfig();
+        pbeConfig.setPassword("c044471d1c49295387aabfc8d00c72ca918da1bc1fa94a146c45b01c22acf54c");
+        pbeConfig.setAlgorithm("PBEWithMD5AndDES");
+        pbeConfig.setKeyObtentionIterations("1000");
+        pbeConfig.setPoolSize("1");
+        pbeConfig.setProviderName("SunJCE");
+        pbeConfig.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        pbeConfig.setStringOutputType("base64");
+        pbeStringEncryptor.setConfig(pbeConfig);
+        return pbeStringEncryptor;
+    }
+}

--- a/backend/src/main/java/peer/backend/config/JasyptConfig.java
+++ b/backend/src/main/java/peer/backend/config/JasyptConfig.java
@@ -14,7 +14,6 @@ public class JasyptConfig {
         SimpleStringPBEConfig pbeConfig = new SimpleStringPBEConfig();
         pbeConfig.setPassword("c044471d1c49295387aabfc8d00c72ca918da1bc1fa94a146c45b01c22acf54c");
         pbeConfig.setAlgorithm("PBEWithMD5AndDES");
-        pbeConfig.setKeyObtentionIterations("1000");
         pbeConfig.setPoolSize("1");
         pbeConfig.setProviderName("SunJCE");
         pbeConfig.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -56,8 +56,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: juhyelee134@gmail.com
-    password: qstrpngbbmmgnyeg
+    username: 42peer@gmail.com
+    password: ENC(DP+YbG1APQcGVpMrg9tVqHL/KpkSB/ESWds1XFsRypE=)
     properties:
       mail:
         smtp:


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- 기존의 메일 계정을 peer계정으로 변경했습니다.
- peer계정의 비밀번호를 암호화 해서 yml 파일 안에 저장했습니다.
- 그리고, JasyptConfig를 추가해서 복호화해서 전송할 수 있도록 했습니다.

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
