### PR TITLE
FEAT: primitive socket controller and service finished

### DIFF
--- a/backend/src/main/java/peer/backend/config/jwt/TokenProvider.java
+++ b/backend/src/main/java/peer/backend/config/jwt/TokenProvider.java
@@ -44,7 +44,7 @@ public class TokenProvider {
         claims.put("sub", user.getId());
         claims.put("role", "ROLE_USER");
 
-        return Jwts.builder()
+        String ret = Jwts.builder()
             .setHeaderParam("typ", "accessToken")
             .setClaims(claims)
             .setIssuedAt(new Date(System.currentTimeMillis()))
@@ -52,6 +52,9 @@ public class TokenProvider {
             .signWith(this.key, SignatureAlgorithm.HS256)
             .compact()
             ;
+//        String redisKey = "redis_" + user.getId().toString();
+//        redisTemplate.opsForValue().set(redisKey, ret);
+        return ret;
     }
 
     public String createRefreshToken(User user) {
@@ -114,6 +117,18 @@ public class TokenProvider {
             }
         }
         return true;
+    }
+
+    public boolean validateToken2(String accessToken) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+//        log.info("key value : " + redisTemplate.opsForValue().get(key));
+
+        try {
+            Jwts.parserBuilder().setSigningKey(this.key).build().parseClaimsJws(accessToken);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     public boolean validRefreshToken(String refreshToken) {

--- a/backend/src/main/java/peer/backend/controller/socket/SocketIoServerController.java
+++ b/backend/src/main/java/peer/backend/controller/socket/SocketIoServerController.java
@@ -1,43 +1,52 @@
 package peer.backend.controller.socket;
 
-import antlr.Token;
+import com.corundumstudio.socketio.AckRequest;
 import com.corundumstudio.socketio.SocketIOClient;
 import com.corundumstudio.socketio.SocketIOServer;
-import com.corundumstudio.socketio.annotation.OnConnect;
-import com.corundumstudio.socketio.annotation.OnDisconnect;
-import com.corundumstudio.socketio.annotation.OnEvent;
 import com.corundumstudio.socketio.listener.ConnectListener;
+import com.corundumstudio.socketio.listener.DataListener;
 import com.corundumstudio.socketio.listener.DisconnectListener;
 import lombok.extern.slf4j.Slf4j;
-import org.aspectj.weaver.ast.Instanceof;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import peer.backend.config.SocketIoConfig;
 import peer.backend.config.jwt.TokenProvider;
 import peer.backend.entity.user.User;
+import peer.backend.repository.user.UserRepository;
+import peer.backend.service.socket.SocketServerService;
 
 import java.util.List;
-import java.util.UUID;
+import java.util.NoSuchElementException;
+
+import peer.backend.dto.socket.tempDTO;
 
 @Component
 @Slf4j
 @RequestMapping("/")
 public class SocketIoServerController {
     private final SocketIOServer server;
+    private final SocketServerService socketServerService;
+    private final UserRepository userRepository;
 
     @Autowired
     private TokenProvider tokenProvider;
 
+    private final RedisTemplate<String, String> redisTemplate;
+
     @Autowired
-    public SocketIoServerController(SocketIoConfig config) {
+    public SocketIoServerController(SocketIoConfig config, SocketServerService socketServerService, UserRepository userRepository, RedisTemplate<String, String> redisTemplate) {
         this.server = config.socketIOServer();
+        this.socketServerService = socketServerService;
+        this.userRepository = userRepository;
+        this.redisTemplate = redisTemplate;
         this.server.start();
         this.server.addConnectListener(onUserConnectWithSocket);
         this.server.addDisconnectListener(onUserDisconnectWithSocket);
+
+        this.server.addEventListener("checkOnline", tempDTO.class, IsHeOnline);
 
     }
 
@@ -46,11 +55,14 @@ public class SocketIoServerController {
         public void onConnect(SocketIOClient client) {
             log.info("Socket is Connected : " + client.getSessionId());
             List<String> token = client.getHandshakeData().getUrlParams().get("token");
-            log.info("Socket Token is Connected : " + client.getHandshakeData().getUrlParams().get("token"));
-            log.info("Token is valid");
+            if (!tokenProvider.validateToken2(token.get(0))) {
+                log.info("Wrong Token! Connection is closed!");
+                client.disconnect();
+            }
             Authentication userJwt = tokenProvider.getAuthentication(token.get(0));
             User user = User.authenticationToUser(userJwt);
-            log.info(user.getName() + "is Online Status");
+            log.info(user.getName() + " is Online Status");
+            redisTemplate.opsForValue().set("onlineStatus:" + user.getId(), client.getSessionId().toString());
         }
     };
 
@@ -58,7 +70,37 @@ public class SocketIoServerController {
     public DisconnectListener onUserDisconnectWithSocket = new DisconnectListener() {
         @Override
         public void onDisconnect(SocketIOClient client) {
+            List<String> token = client.getHandshakeData().getUrlParams().get("token");
+            Authentication userJwt = tokenProvider.getAuthentication(token.get(0));
+            User user = User.authenticationToUser(userJwt);
+            redisTemplate.delete("onlineStatus:" + user.getId());
+            log.info(user.getName() + " is offline Status");
             log.info("Socket is disconnected : " + client.getSessionId());
+        }
+    };
+
+    public DataListener<tempDTO> IsHeOnline = new DataListener<>() {
+        @Override
+        public void onData(SocketIOClient client, tempDTO data, AckRequest ackSender) throws Exception {
+            Long userId;
+            User user;
+            try {
+                userId = Long.parseLong(data.getData());
+                user = userRepository.findById(userId).orElseThrow(() -> new NoSuchElementException("User doesn't exist!"));
+            } catch (NumberFormatException e) {
+                client.sendEvent("checkOnline", "Can not find user!");
+                return ;
+            } catch (NoSuchElementException e) {
+                client.sendEvent("checkOnline", e.getMessage());
+                return ;
+            }
+            if(socketServerService.IsOnline(user)) {
+                log.info(user.getNickname() + " is Online!");
+                client.sendEvent("checkOnline", user.getNickname() + " is Online!");
+            }else{
+                log.info(user.getNickname() + " is offline!");
+                client.sendEvent("checkOnline", user.getNickname() + " is offline!");
+            }
         }
     };
 }

--- a/backend/src/main/java/peer/backend/dto/socket/tempDTO.java
+++ b/backend/src/main/java/peer/backend/dto/socket/tempDTO.java
@@ -1,0 +1,12 @@
+package peer.backend.dto.socket;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class tempDTO {
+    public String data;
+}

--- a/backend/src/main/java/peer/backend/service/socket/SocketServerService.java
+++ b/backend/src/main/java/peer/backend/service/socket/SocketServerService.java
@@ -1,0 +1,19 @@
+package peer.backend.service.socket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import peer.backend.entity.user.User;
+
+@Service
+@RequiredArgsConstructor
+public class SocketServerService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public boolean IsOnline(User user) {
+        if (redisTemplate.opsForValue().get("onlineStatus:" + user.getId()) != null)
+            return true;
+        return false;
+    }
+}


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- 소켓 커넥션 연결 컨트롤러 구성 완료
- 소켓 커넥션 연결 서비스 구성 완료
- 서비스에서 의존성 주입을 통해 online 여부 파악 가능하도록 구성 완료
- 기존 valid access token 의 문제점 발견하여 임시로 valid 방식을 바꿔서 구성 완료


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
- socket.io 를 통한 커넥션 연결 확인 완료 
- service 내부의 isOnline 메서드 점검 완료 
- redis 캐쉬에 정상 등록 여부 확인 완료
