### PR TITLE
407 hotfix personal auth

### DIFF
--- a/backend/src/main/java/peer/backend/dto/profile/response/PersonalInfoResponse.java
+++ b/backend/src/main/java/peer/backend/dto/profile/response/PersonalInfoResponse.java
@@ -2,12 +2,15 @@ package peer.backend.dto.profile.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 public class PersonalInfoResponse {
     private String name;
     private String email;
     private String local;
-    private String authentication;
+    private String authenticationFt;
+    private String authenticationGoogle;
 }

--- a/backend/src/main/java/peer/backend/repository/user/SocialLoginRepository.java
+++ b/backend/src/main/java/peer/backend/repository/user/SocialLoginRepository.java
@@ -1,5 +1,6 @@
 package peer.backend.repository.user;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import peer.backend.entity.user.SocialLogin;
@@ -9,4 +10,5 @@ public interface SocialLoginRepository extends JpaRepository<SocialLogin, Long> 
     Optional<SocialLogin> findByEmail(String email);
 
     boolean existsByEmail(String email);
+    List<SocialLogin> findAllByUserId(Long userId);
 }

--- a/backend/src/main/java/peer/backend/service/profile/PersonalInfoService.java
+++ b/backend/src/main/java/peer/backend/service/profile/PersonalInfoService.java
@@ -39,10 +39,10 @@ public class PersonalInfoService {
         for (SocialLogin socialLogin : socialLoginList) {
             switch (socialLogin.getProvider().getValue()) {
                 case "ft" :
-                    info.setAuthenticationFt("ft");
+                    info.setAuthenticationFt(socialLogin.getIntraId());
                     break;
                 case "google" :
-                    info.setAuthenticationGoogle("google");
+                    info.setAuthenticationGoogle(socialLogin.getEmail());
                     break;
                 case "github" :
                     break;

--- a/backend/src/main/java/peer/backend/service/profile/PersonalInfoService.java
+++ b/backend/src/main/java/peer/backend/service/profile/PersonalInfoService.java
@@ -7,28 +7,48 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import peer.backend.dto.profile.request.PasswordRequest;
 import peer.backend.dto.profile.response.PersonalInfoResponse;
+import peer.backend.entity.user.SocialLogin;
 import peer.backend.entity.user.User;
 import peer.backend.exception.BadRequestException;
 import peer.backend.exception.ForbiddenException;
 import peer.backend.exception.NotFoundException;
 import peer.backend.oauth.PrincipalDetails;
+import peer.backend.repository.user.SocialLoginRepository;
 import peer.backend.repository.user.UserRepository;
+
+import java.util.List;
 
 
 @Service
 @RequiredArgsConstructor
 public class PersonalInfoService {
     private final UserRepository userRepository;
+    private final SocialLoginRepository socialLoginRepository;
 
     @Transactional(readOnly = true)
     public PersonalInfoResponse getPersonalInfo(Authentication auth) {
         User user = User.authenticationToUser(auth);
-        return PersonalInfoResponse.builder()
+        List<SocialLogin> socialLoginList = socialLoginRepository.findAllByUserId(user.getId());
+        PersonalInfoResponse info = PersonalInfoResponse.builder()
                 .name(user.getName())
                 .email(user.getEmail())
                 .local(user.getAddress())
-                .authentication(user.getCompany())
+                .authenticationFt(null)
+                .authenticationGoogle(null)
                 .build();
+        for (SocialLogin socialLogin : socialLoginList) {
+            switch (socialLogin.getProvider().getValue()) {
+                case "ft" :
+                    info.setAuthenticationFt("ft");
+                    break;
+                case "google" :
+                    info.setAuthenticationGoogle("google");
+                    break;
+                case "github" :
+                    break;
+            }
+        }
+        return info;
     }
 
     @Transactional

--- a/backend/src/test/java/peer/backend/profile/PersonalInfoServiceTest.java
+++ b/backend/src/test/java/peer/backend/profile/PersonalInfoServiceTest.java
@@ -65,10 +65,12 @@ public class PersonalInfoServiceTest {
         socialLogins = new ArrayList<>();
         SocialLogin socialLogin1 = SocialLogin.builder()
                 .user(user)
+                .intraId("intraId")
                 .provider(SocialLoginProvider.FT)
                 .build();
         SocialLogin socialLogin2 = SocialLogin.builder()
                 .user(user)
+                .email("gmail")
                 .provider(SocialLoginProvider.GOOGLE)
                 .build();
         socialLogins.add(socialLogin1);
@@ -83,8 +85,8 @@ public class PersonalInfoServiceTest {
         assertThat(info.getEmail()).isEqualTo(user.getEmail());
         assertThat(info.getName()).isEqualTo(user.getName());
         assertThat(info.getLocal()).isEqualTo(user.getAddress());
-        assertThat(info.getAuthenticationFt()).isEqualTo("ft");
-        assertThat(info.getAuthenticationGoogle()).isEqualTo("google");
+        assertThat(info.getAuthenticationFt()).isEqualTo("intraId");
+        assertThat(info.getAuthenticationGoogle()).isEqualTo("gmail");
     }
 
     @Test


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- authentication을 authenticationFt 와 authenticationGoogle로 나누었습니다.
- authenticationFt는 42 인트라를 가지도록, authenticationGoogle은 gmail 주소를 가지도록 했습니다.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
