### PR TITLE
[HOTFIX] #405 메인페이지에서 모집글 검색시 due를 기간으로 검색하기

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -84,6 +84,9 @@ dependencies {
 
     // json createdAt
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.3'
+
+    // prepersistence
+    implementation 'jakarta.persistence:jakarta.persistence-api:2.2.3'
     // 사용 가능한 최신 버전 사용
 
 //    implementation 'org.apache.httpcomponents:httpclient:4.5.13'

--- a/backend/src/main/java/peer/backend/controller/board/RecruitController.java
+++ b/backend/src/main/java/peer/backend/controller/board/RecruitController.java
@@ -43,8 +43,6 @@ public class RecruitController {
     @PostMapping("/write")
     public void createRecruit(@RequestBody RecruitCreateRequest request, Authentication auth) throws IOException{
         request.setType(request.getType().toUpperCase());
-//        request.setPlace(request.getPlace().toUpperCase());
-//        System.out.println(request.getPlace());
         recruitService.createRecruit(request, auth);
     }
 
@@ -67,9 +65,8 @@ public class RecruitController {
         recruitService.applyRecruit(recruit_id, request, auth);
     }
     @PostMapping("/favorite/{recruit_id}")
-    public void goFavorite(@PathVariable Long recruit_id, Principal principal){
-        User user = userRepository.findByName(principal.getName()).orElseThrow( () -> new NotFoundException("존재하지 않는 유저입니다."));
-        recruitService.changeRecruitFavorite(user.getId(), recruit_id );
+    public void goFavorite(@PathVariable Long recruit_id, Authentication auth){
+        recruitService.changeRecruitFavorite(auth, recruit_id );
     }
 
     //TODO:admin에 tag 관리 기능이 만들어지면 해당 내용 수정 필요

--- a/backend/src/main/java/peer/backend/controller/board/RecruitController.java
+++ b/backend/src/main/java/peer/backend/controller/board/RecruitController.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import peer.backend.annotation.AuthorCheck;
 import peer.backend.dto.board.recruit.*;
 import peer.backend.entity.board.recruit.Tag;
+import peer.backend.entity.board.recruit.enums.RecruitDueEnum;
 import peer.backend.entity.user.User;
 import peer.backend.exception.NotFoundException;
 import peer.backend.repository.user.UserRepository;
@@ -24,7 +25,6 @@ import java.util.List;
 @RequestMapping("/api/v1/recruit")
 public class RecruitController {
     private final RecruitService recruitService;
-    private final UserRepository userRepository;
 
     @ApiOperation(value = "", notes = "모집게시글을 불러온다.")
     @GetMapping("/{recruit_id}")
@@ -42,7 +42,6 @@ public class RecruitController {
     @ApiOperation(value = "", notes = "모집글과 팀을 함께 생성한다.")
     @PostMapping("/write")
     public void createRecruit(@RequestBody RecruitCreateRequest request, Authentication auth) throws IOException{
-        request.setType(request.getType().toUpperCase());
         recruitService.createRecruit(request, auth);
     }
 

--- a/backend/src/main/java/peer/backend/dto/board/recruit/RecruitCreateRequest.java
+++ b/backend/src/main/java/peer/backend/dto/board/recruit/RecruitCreateRequest.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/backend/src/main/java/peer/backend/dto/board/recruit/RecruitListRequest.java
+++ b/backend/src/main/java/peer/backend/dto/board/recruit/RecruitListRequest.java
@@ -28,8 +28,6 @@ public class RecruitListRequest{
     private String sort;
     private String keyword;
     private List<String> due;
-    private RecruitDueEnum start = RecruitDueEnum.from(due.get(0));
-    private RecruitDueEnum end = RecruitDueEnum.from(due.get(1));
     private String region1;
     private String region2;
     private List<String> place;

--- a/backend/src/main/java/peer/backend/dto/board/recruit/RecruitListRequest.java
+++ b/backend/src/main/java/peer/backend/dto/board/recruit/RecruitListRequest.java
@@ -1,6 +1,7 @@
 package peer.backend.dto.board.recruit;
 
 import lombok.*;
+import peer.backend.entity.board.recruit.enums.RecruitDueEnum;
 
 import java.util.List;
 
@@ -26,7 +27,9 @@ public class RecruitListRequest{
     private String type;
     private String sort;
     private String keyword;
-    private String due;
+    private List<String> due;
+    private RecruitDueEnum start = RecruitDueEnum.from(due.get(0));
+    private RecruitDueEnum end = RecruitDueEnum.from(due.get(1));
     private String region1;
     private String region2;
     private List<String> place;

--- a/backend/src/main/java/peer/backend/dto/board/recruit/RecruitListRequest.java
+++ b/backend/src/main/java/peer/backend/dto/board/recruit/RecruitListRequest.java
@@ -1,21 +1,11 @@
 package peer.backend.dto.board.recruit;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import peer.backend.entity.board.recruit.enums.RecruitDueEnum;
 
 import java.util.List;
 
-
-//   "title" : "string"
-//           "due" : "string"
-//           "type" : enum
-//    "content" : "string"
-//            "user_id" : " number",
-//            "region" : "string"
-//            "link" : "string"
-//            "tag" ": "tagList[]"
-//            "role" "List<Role>" { "role name" : "프론트", "number" : 5 }
-//            "interviewList" : interviewList
 @Getter
 @Setter
 @Builder
@@ -28,9 +18,20 @@ public class RecruitListRequest{
     private String sort;
     private String keyword;
     private List<String> due;
+    private int start;
+    private int end;
     private String region1;
     private String region2;
     private List<String> place;
     private List<String> status;
     private List<String> tag;
+
+    @JsonProperty("start")
+    public int getStart() {
+        return due.get(0) != null ? RecruitDueEnum.from(due.get(0)).getValue() : null;
+    }
+    @JsonProperty("end")
+    public int getEnd() {
+        return due.get(1) != null ? RecruitDueEnum.from(due.get(1)).getValue() : null;
+    }
 }

--- a/backend/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -2,22 +2,8 @@ package peer.backend.entity.board.recruit;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -45,15 +45,15 @@ public class Recruit extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User writer;
 
-    @OneToMany(mappedBy = "recruit", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecruitFavorite> favorites = new ArrayList<>();
-    @OneToMany(mappedBy = "recruit", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecruitApplicant> applicants = new ArrayList<>();
-    @OneToMany(mappedBy = "recruit", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecruitRole> roles = new ArrayList<>();
-    @OneToMany(mappedBy = "recruit", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecruitInterview> interviews = new ArrayList<>();
-    @OneToMany(mappedBy = "recruit", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecruitFile> files = new ArrayList<>();
 
     @Column

--- a/backend/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -63,6 +63,7 @@ public class Recruit extends BaseEntity {
     private String title;
     @Enumerated(EnumType.STRING)
     private RecruitDueEnum due;
+    private int dueValue;
     @Column
     private String content;
     @Column
@@ -85,6 +86,13 @@ public class Recruit extends BaseEntity {
     private Long writerId;
 
 
+    @PrePersist
+    @PreUpdate
+    private void updateDueValue() {
+        if (this.due != null) {
+            this.dueValue = this.due.getValue();
+        }
+    }
 
     public void update(RecruitUpdateRequestDTO request, String filePath){
         this.title = request.getTitle();

--- a/backend/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -11,6 +11,7 @@ import peer.backend.dto.board.recruit.RecruitRoleDTO;
 import peer.backend.dto.board.recruit.RecruitUpdateRequestDTO;
 import peer.backend.dto.board.recruit.TagListResponse;
 import peer.backend.entity.BaseEntity;
+import peer.backend.entity.board.recruit.enums.RecruitDueEnum;
 import peer.backend.entity.board.recruit.enums.RecruitInterviewType;
 import peer.backend.entity.board.recruit.enums.RecruitStatus;
 import peer.backend.entity.team.Team;
@@ -60,8 +61,8 @@ public class Recruit extends BaseEntity {
     private Long hit = 0L;
     @Column
     private String title;
-    @Column
-    private String due;
+    @Enumerated(EnumType.STRING)
+    private RecruitDueEnum due;
     @Column
     private String content;
     @Column
@@ -87,7 +88,7 @@ public class Recruit extends BaseEntity {
 
     public void update(RecruitUpdateRequestDTO request, String filePath){
         this.title = request.getTitle();
-        this.due = request.getDue();
+        this.due = RecruitDueEnum.from(request.getDue());
         this.content = request.getContent();
         this.status = request.getStatus();
         this.region1 = (request.getPlace().equals("온라인") ? null : request.getRegion1());

--- a/backend/src/main/java/peer/backend/entity/board/recruit/enums/RecruitDueEnum.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/enums/RecruitDueEnum.java
@@ -1,0 +1,43 @@
+package peer.backend.entity.board.recruit.enums;
+
+import lombok.Getter;
+
+
+@Getter
+public enum RecruitDueEnum {
+    ONE_WEEK(1, "1주일"),
+    TWO_WEEKS(2, "2주일"),
+    THREE_WEEKS(3, "3주일"),
+    FOUR_WEEKS(4, "4주일"),
+    ONE_MONTH(5, "1개월"),
+    TWO_MONTHS(6, "2개월")
+    ;
+    // ... 나머지 값들 ...
+
+    private final int value;
+    private final String label;
+
+    RecruitDueEnum(int value, String label) {
+        this.value = value;
+        this.label = label;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    // 문자열로부터 enum 값을 찾는 정적 메소드
+    public static RecruitDueEnum from(String label) {
+        for (RecruitDueEnum d : RecruitDueEnum.values()) {
+            if (d.label.equalsIgnoreCase(label)) {
+                return d;
+            }
+        }
+        throw new IllegalArgumentException("잘못된 기간입니다.");
+    }
+    }
+

--- a/backend/src/main/java/peer/backend/entity/board/recruit/enums/RecruitDueEnum.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/enums/RecruitDueEnum.java
@@ -46,5 +46,5 @@ public enum RecruitDueEnum {
         }
         throw new IllegalArgumentException("잘못된 기간입니다.");
     }
-    }
+}
 

--- a/backend/src/main/java/peer/backend/entity/board/recruit/enums/RecruitDueEnum.java
+++ b/backend/src/main/java/peer/backend/entity/board/recruit/enums/RecruitDueEnum.java
@@ -1,26 +1,33 @@
 package peer.backend.entity.board.recruit.enums;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 
 @Getter
+@RequiredArgsConstructor
 public enum RecruitDueEnum {
     ONE_WEEK(1, "1주일"),
     TWO_WEEKS(2, "2주일"),
     THREE_WEEKS(3, "3주일"),
     FOUR_WEEKS(4, "4주일"),
     ONE_MONTH(5, "1개월"),
-    TWO_MONTHS(6, "2개월")
+    TWO_MONTHS(6, "2개월"),
+    THREE_MONTHS(7, "3개월"),
+    FOUR_MONTHS(8, "4개월"),
+    FIVE_MONTHS(9, "5개월"),
+    SIX_MONTHS(10, "6개월"),
+    SEVEN_MONTHS(11, "7개월"),
+    EIGHT_MONTHS(12, "8개월"),
+    NINE_MONTHS(13, "9개월"),
+    TEN_MONTHS(14, "10개월"),
+    ELEVEN_MONTHS(15, "11개월"),
+    TWELVE_MONTHS(16, "12개월"),
+    TWELVE_ABOVE(17, "12개월 이상")
     ;
-    // ... 나머지 값들 ...
 
     private final int value;
     private final String label;
-
-    RecruitDueEnum(int value, String label) {
-        this.value = value;
-        this.label = label;
-    }
 
     public int getValue() {
         return value;

--- a/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -138,9 +138,7 @@ public class RecruitService {
             predicates.add(cb.equal(recruit.get("region2"), request.getRegion2()));
         }
         if (request.getDue() != null && !request.getDue().isEmpty()) {
-            RecruitDueEnum start = RecruitDueEnum.from(request.getDue().get(0));
-            RecruitDueEnum end = RecruitDueEnum.from(request.getDue().get(1));
-            predicates.add(cb.between(recruit.get("dueValue"), start.getValue(), end.getValue()));
+            predicates.add(cb.between(recruit.get("dueValue"), request.getStart(), request.getEnd()));
         }
         if (request.getKeyword() != null && !request.getKeyword().isEmpty()) {
             predicates.add(cb.like(recruit.get("title"), "%" + request.getKeyword() + "%"));

--- a/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -140,9 +140,7 @@ public class RecruitService {
         if (request.getDue() != null && !request.getDue().isEmpty()) {
             RecruitDueEnum start = RecruitDueEnum.from(request.getDue().get(0));
             RecruitDueEnum end = RecruitDueEnum.from(request.getDue().get(1));
-            predicates.add(cb.and(
-                    cb.greaterThanOrEqualTo(recruit.get("dueValue"), start.getValue()),
-                    cb.lessThanOrEqualTo(recruit.get("dueValue"), end.getValue())));
+            predicates.add(cb.between(recruit.get("dueValue"), start.getValue(), end.getValue()));
         }
         if (request.getKeyword() != null && !request.getKeyword().isEmpty()) {
             predicates.add(cb.like(recruit.get("title"), "%" + request.getKeyword() + "%"));
@@ -160,7 +158,7 @@ public class RecruitService {
                 throw new IllegalArgumentException("Invalid sort value");
         }
         //query 전송
-// Pageable 적용
+// order 적용
         cq.orderBy(orders);
 
 // Predicate 적용

--- a/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -3,6 +3,7 @@ package peer.backend.service.board.recruit;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.tika.utils.AnnotationUtils;
+import org.aspectj.weaver.ast.Expr;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -140,8 +141,8 @@ public class RecruitService {
             RecruitDueEnum start = RecruitDueEnum.from(request.getDue().get(0));
             RecruitDueEnum end = RecruitDueEnum.from(request.getDue().get(1));
             predicates.add(cb.and(
-                    cb.greaterThanOrEqualTo(recruit.get("due").get("value"), start),
-                    cb.lessThanOrEqualTo(recruit.get("due").get("value"), end)));
+                    cb.greaterThanOrEqualTo(recruit.get("dueValue"), start.getValue()),
+                    cb.lessThanOrEqualTo(recruit.get("dueValue"), end.getValue())));
         }
         if (request.getKeyword() != null && !request.getKeyword().isEmpty()) {
             predicates.add(cb.like(recruit.get("title"), "%" + request.getKeyword() + "%"));

--- a/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -343,13 +343,14 @@ public class RecruitService {
 
     @Transactional
     @RecruitWritingTracking
-    public Recruit createRecruit(RecruitCreateRequest request, User user)
+    public Recruit createRecruit(RecruitCreateRequest request, Authentication auth)
         throws IOException {
         //동일한 팀 이름 검사
         Optional<Team> findTeam = teamRepository.findByName(request.getName());
         if (findTeam.isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 팀 이름입니다.");
         }
+        User user = User.authenticationToUser(auth);
         //팀 생성
         Team team = this.teamService.createTeam(user, request);
 

--- a/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/backend/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -105,7 +105,6 @@ public class RecruitService {
         RecruitListRequest request, Authentication auth) {
         //TODO:favorite 등
         //query 생성 준비
-
         CriteriaBuilder cb = em.getCriteriaBuilder();
         CriteriaQuery<Recruit> cq = cb.createQuery(Recruit.class).distinct(true);
         Root<Recruit> recruit = cq.from(Recruit.class);
@@ -138,10 +137,11 @@ public class RecruitService {
             predicates.add(cb.equal(recruit.get("region2"), request.getRegion2()));
         }
         if (request.getDue() != null && !request.getDue().isEmpty()) {
+            RecruitDueEnum start = RecruitDueEnum.from(request.getDue().get(0));
+            RecruitDueEnum end = RecruitDueEnum.from(request.getDue().get(1));
             predicates.add(cb.and(
-                    cb.greaterThanOrEqualTo(recruit.get("start").get("value"), request.getStart().getValue()),
-                    cb.lessThanOrEqualTo(recruit.get("duration").get("value"), request.getEnd().getValue()))
-            );
+                    cb.greaterThanOrEqualTo(recruit.get("due").get("value"), start),
+                    cb.lessThanOrEqualTo(recruit.get("due").get("value"), end)));
         }
         if (request.getKeyword() != null && !request.getKeyword().isEmpty()) {
             predicates.add(cb.like(recruit.get("title"), "%" + request.getKeyword() + "%"));
@@ -208,7 +208,7 @@ public class RecruitService {
             .region(new ArrayList<>(List.of(recruit.getRegion1(), recruit.getRegion2())))
             .status(recruit.getStatus())
             .totalNumber(recruit.getRoles().size())
-            .due(recruit.getDue())
+            .due(recruit.getDue().getLabel())
             .link(recruit.getLink())
             .leader_id(recruit.getWriter().getId())
             .leader_nickname(recruit.getWriter().getNickname())
@@ -234,7 +234,7 @@ public class RecruitService {
             .region2(recruit.getRegion2())
             .status(recruit.getStatus())
             .totalNumber(recruit.getRoles().size())
-            .due(recruit.getDue())
+            .due(recruit.getDue().getLabel())
             .link(recruit.getLink())
             .leader_id(recruit.getWriter().getId())
             .leader_nickname(recruit.getWriter().getNickname())
@@ -290,7 +290,7 @@ public class RecruitService {
             .team(team)
             .type(TeamType.valueOf(request.getType()))
             .title(request.getTitle())
-            .due(request.getDue())
+            .due(RecruitDueEnum.from(request.getDue()))
             .link(request.getLink())
             .content(request.getContent())
             .place(TeamOperationFormat.valueOf(request.getPlace()))


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- due 기간 검색을 위하여 string과 int값을 갖는 RecruitDueEnum 추가 -> dto, entity가 해당 enum을 사용하도록 수정
- due 기간 검색을 위하여 Recruit엔티티에 dueValue필드 추가,  RecruitListRequestDto에 start, end field 추가.
두 값 모두 due의 enumType의 value값을 저장함
- favorite 기능 사용시 principal 대신 auth 사용하도록 수정
- recruit OneToMany를 갖는 하위 엔티티들의 cascade를 all로 수정
- recruitApply시에 role이 null값이 경우 id라서 Null이 허용되지 않아 null이 들어올 경우 ""를 입력하도록 수정


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
