### PR TITLE
[FIX] OAuth 예외 상황 처리

### DIFF
--- a/backend/src/main/java/peer/backend/controller/SignUpController.java
+++ b/backend/src/main/java/peer/backend/controller/SignUpController.java
@@ -33,7 +33,7 @@ public class SignUpController {
     public ResponseEntity<Object> sendEmail(@Valid @RequestBody EmailAddress address) {
         String email = address.getEmail();
 
-        if (!this.memberService.emailDuplicationCheck(email)) {
+        if (this.memberService.emailDuplicationCheck(email)) {
             throw new ConflictException("이미 존재하는 이메일입니다!");
         }
 

--- a/backend/src/main/java/peer/backend/service/EmailAuthService.java
+++ b/backend/src/main/java/peer/backend/service/EmailAuthService.java
@@ -20,6 +20,7 @@ public class EmailAuthService {
 
     private final JavaMailSender sender;
     private final RedisTemplate<String, String> redisTemplate;
+    private static final String EMAIL_REDIS_KEY_PREFIX = "email-auth:";
 
     private String getAuthCode(String email) {
         Random random = new Random();
@@ -63,17 +64,18 @@ public class EmailAuthService {
     }
 
     public void emailCodeVerification(String email, String code) {
-        String redisCode = this.redisTemplate.opsForValue().get(email);
+        String redisCode = this.redisTemplate.opsForValue().get(EMAIL_REDIS_KEY_PREFIX + email);
         if (redisCode == null) {
             throw new BadRequestException("잘못된 이메일입니다!");
         }
         if (!redisCode.equals(code)) {
             throw new UnauthorizedException("잘못된 인증 코드입니다!");
         }
-        this.redisTemplate.delete(email);
+        this.redisTemplate.delete(EMAIL_REDIS_KEY_PREFIX + email);
     }
 
     private void putRedisEmailCode(String email, String code) {
-        this.redisTemplate.opsForValue().set(email, code, 5, TimeUnit.MINUTES);
+        this.redisTemplate.opsForValue()
+            .set(EMAIL_REDIS_KEY_PREFIX + email, code, 5, TimeUnit.MINUTES);
     }
 }

--- a/backend/src/main/java/peer/backend/service/MemberService.java
+++ b/backend/src/main/java/peer/backend/service/MemberService.java
@@ -47,11 +47,11 @@ public class MemberService {
         User savedUser = this.userService.saveUser(user);
         String socialEmail = info.getSocialEmail();
         if (socialEmail != null) {
-            SocialLogin socialLogin = this.redisTemplate.opsForValue().get(socialEmail);
+            SocialLogin socialLogin = this.socialLoginService.getSocialLoginInRedis(socialEmail);
             if (socialLogin != null) {
                 socialLogin.setUser(savedUser);
                 this.socialLoginService.save(socialLogin);
-                this.redisTemplate.delete(socialEmail);
+                this.socialLoginService.deleteSocialLoginInRedis(socialEmail);
                 savedUser.addSocialLogin(socialLogin);
             } else {
                 throw new ConflictException("잘못된 소셜 로그인 이메일입니다!");
@@ -91,18 +91,13 @@ public class MemberService {
 
     @Transactional
     public boolean emailExistsCheck(String email) {
-        User user = this.userRepository.findByEmail(email).orElse(null);
-        if (!this.userRepository.existsByEmail(email)) {
-            return false;
-        }
-        return true;
+        return this.userRepository.existsByEmail(email);
     }
 
     @Transactional
     public User getUserByEmail(String email) {
-        User user = this.userRepository.findByEmail(email)
+        return this.userRepository.findByEmail(email)
             .orElseThrow(() -> new NotFoundException("해당 이메일의 유저가 없습니다!"));
-        return user;
     }
 
     @Transactional
@@ -114,7 +109,7 @@ public class MemberService {
         final String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
         SecureRandom rm = new SecureRandom();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < 10; i++) {
             //무작위로 문자열의 인덱스 반환

--- a/backend/src/main/java/peer/backend/service/MemberService.java
+++ b/backend/src/main/java/peer/backend/service/MemberService.java
@@ -81,12 +81,9 @@ public class MemberService {
     public boolean emailDuplicationCheck(String email) {
         User user = this.userRepository.findByEmail(email).orElse(null);
         if (this.userRepository.existsByEmail(email)) {
-            return false;
+            return true;
         }
-        if (this.socialLoginRepository.existsByEmail(email)) {
-            return false;
-        }
-        return true;
+        return this.socialLoginRepository.existsByEmail(email);
     }
 
     @Transactional

--- a/backend/src/main/java/peer/backend/service/SocialLoginService.java
+++ b/backend/src/main/java/peer/backend/service/SocialLoginService.java
@@ -1,5 +1,6 @@
 package peer.backend.service;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +38,9 @@ public class SocialLoginService {
 
     public SocialLogin getSocialLoginInRedis(String email) {
         return this.redisTemplate.opsForValue().get(SOCIAL_REDIS_KEY_PREFIX + email);
+    }
+
+    public List<SocialLogin> getSocialLoginListByUserId(Long id) {
+        return this.socialLoginRepository.findAllByUserId(id);
     }
 }

--- a/backend/src/main/java/peer/backend/service/SocialLoginService.java
+++ b/backend/src/main/java/peer/backend/service/SocialLoginService.java
@@ -14,6 +14,7 @@ public class SocialLoginService {
 
     private final SocialLoginRepository socialLoginRepository;
     private final RedisTemplate<String, SocialLogin> redisTemplate;
+    public static final String SOCIAL_REDIS_KEY_PREFIX = "social-email:";
 
     @Transactional
     public SocialLogin getSocialLogin(String email) {
@@ -26,7 +27,15 @@ public class SocialLoginService {
 
     public void putSocialLoginInRedis(SocialLogin socialLogin) {
         this.redisTemplate.opsForValue()
-            .set(socialLogin.getEmail(), socialLogin, 3,
+            .set(SOCIAL_REDIS_KEY_PREFIX + socialLogin.getEmail(), socialLogin, 3,
                 TimeUnit.HOURS);
+    }
+
+    public void deleteSocialLoginInRedis(String email) {
+        this.redisTemplate.delete(SOCIAL_REDIS_KEY_PREFIX + email);
+    }
+
+    public SocialLogin getSocialLoginInRedis(String email) {
+        return this.redisTemplate.opsForValue().get(SOCIAL_REDIS_KEY_PREFIX + email);
     }
 }

--- a/backend/src/main/java/peer/backend/service/profile/PersonalInfoService.java
+++ b/backend/src/main/java/peer/backend/service/profile/PersonalInfoService.java
@@ -1,5 +1,6 @@
 package peer.backend.service.profile;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -11,40 +12,40 @@ import peer.backend.entity.user.SocialLogin;
 import peer.backend.entity.user.User;
 import peer.backend.exception.BadRequestException;
 import peer.backend.exception.ForbiddenException;
-import peer.backend.exception.NotFoundException;
-import peer.backend.oauth.PrincipalDetails;
 import peer.backend.repository.user.SocialLoginRepository;
 import peer.backend.repository.user.UserRepository;
-
-import java.util.List;
+import peer.backend.service.SocialLoginService;
 
 
 @Service
 @RequiredArgsConstructor
 public class PersonalInfoService {
+
     private final UserRepository userRepository;
     private final SocialLoginRepository socialLoginRepository;
+    private final SocialLoginService socialLoginService;
 
     @Transactional(readOnly = true)
     public PersonalInfoResponse getPersonalInfo(Authentication auth) {
         User user = User.authenticationToUser(auth);
-        List<SocialLogin> socialLoginList = socialLoginRepository.findAllByUserId(user.getId());
+        List<SocialLogin> socialLoginList = this.socialLoginService.getSocialLoginListByUserId(
+            user.getId());
         PersonalInfoResponse info = PersonalInfoResponse.builder()
-                .name(user.getName())
-                .email(user.getEmail())
-                .local(user.getAddress())
-                .authenticationFt(null)
-                .authenticationGoogle(null)
-                .build();
+            .name(user.getName())
+            .email(user.getEmail())
+            .local(user.getAddress())
+            .authenticationFt(null)
+            .authenticationGoogle(null)
+            .build();
         for (SocialLogin socialLogin : socialLoginList) {
             switch (socialLogin.getProvider().getValue()) {
-                case "ft" :
+                case "ft":
                     info.setAuthenticationFt(socialLogin.getIntraId());
                     break;
-                case "google" :
+                case "google":
                     info.setAuthenticationGoogle(socialLogin.getEmail());
                     break;
-                case "github" :
+                case "github":
                     break;
             }
         }

--- a/backend/src/test/java/peer/backend/profile/PersonalInfoServiceTest.java
+++ b/backend/src/test/java/peer/backend/profile/PersonalInfoServiceTest.java
@@ -1,8 +1,14 @@
 package peer.backend.profile;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -18,22 +24,19 @@ import peer.backend.oauth.PrincipalDetails;
 import peer.backend.oauth.enums.SocialLoginProvider;
 import peer.backend.repository.user.SocialLoginRepository;
 import peer.backend.repository.user.UserRepository;
+import peer.backend.service.SocialLoginService;
 import peer.backend.service.profile.PersonalInfoService;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Test PersonalInfoService")
 public class PersonalInfoServiceTest {
+
     @Mock
     UserRepository userRepository;
     @Mock
     SocialLoginRepository socialLoginRepository;
+    @Mock
+    SocialLoginService socialLoginService;
     @InjectMocks
     PersonalInfoService personalInfoService;
     String name;
@@ -43,36 +46,38 @@ public class PersonalInfoServiceTest {
     Authentication auth;
     BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
     List<SocialLogin> socialLogins;
+
     @BeforeEach
     void beforeEach() {
         name = "test name";
         password = "test password";
         user = User.builder()
-                .id(1L)
-                .email("test@email.com")
-                .password(encoder.encode("test password"))
-                .name(name)
-                .nickname("test nickname")
-                .isAlarm(false)
-                .address("test address")
-                .imageUrl("tes image URL")
-                .build();
+            .id(1L)
+            .email("test@email.com")
+            .password(encoder.encode("test password"))
+            .name(name)
+            .nickname("test nickname")
+            .isAlarm(false)
+            .address("test address")
+            .imageUrl("tes image URL")
+            .build();
         newPassword = new PasswordRequest(
-                password, "new password", "new password"
+            password, "new password", "new password"
         );
         PrincipalDetails details = new PrincipalDetails(user);
-        auth = new UsernamePasswordAuthenticationToken(details, details.getPassword(), details.getAuthorities());
+        auth = new UsernamePasswordAuthenticationToken(details, details.getPassword(),
+            details.getAuthorities());
         socialLogins = new ArrayList<>();
         SocialLogin socialLogin1 = SocialLogin.builder()
-                .user(user)
-                .intraId("intraId")
-                .provider(SocialLoginProvider.FT)
-                .build();
+            .user(user)
+            .intraId("intraId")
+            .provider(SocialLoginProvider.FT)
+            .build();
         SocialLogin socialLogin2 = SocialLogin.builder()
-                .user(user)
-                .email("gmail")
-                .provider(SocialLoginProvider.GOOGLE)
-                .build();
+            .user(user)
+            .email("gmail")
+            .provider(SocialLoginProvider.GOOGLE)
+            .build();
         socialLogins.add(socialLogin1);
         socialLogins.add(socialLogin2);
     }
@@ -80,7 +85,7 @@ public class PersonalInfoServiceTest {
     @Test
     @DisplayName("개인 정보 조회 테스트")
     public void getPersonalInfoTest() {
-        when(socialLoginRepository.findAllByUserId(anyLong())).thenReturn(socialLogins);
+        when(socialLoginService.getSocialLoginListByUserId(anyLong())).thenReturn(socialLogins);
         PersonalInfoResponse info = personalInfoService.getPersonalInfo(auth);
         assertThat(info.getEmail()).isEqualTo(user.getEmail());
         assertThat(info.getName()).isEqualTo(user.getName());


### PR DESCRIPTION
## 변경 사항
- OAuth 로그인 한 소셜 계정 이메일과 회원가입 시 적는 이메일이 동일할때 발생하던 문제 해결
- 이미 소셜 계쩡이 연동이 되었는데 또 해당 소셜 서비스로 또 연동을 시도할 경우 막는 로직 추가
- 레디스 사용하던 부분 짜잘 리팩토링(서비스 내의 함수로 래핑함)



<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
