### PR TITLE
[FIX] XSSFWorkbook close

### DIFF
--- a/src/main/java/peer/backend/service/ExcelService.java
+++ b/src/main/java/peer/backend/service/ExcelService.java
@@ -57,6 +57,7 @@ public class ExcelService {
         createActivityTrackingSheet(activityTrackingList, activityTrackingSheet, headerCellStyle);
 
         workbook.write(out);
+        workbook.close();
         return new ByteArrayInputStream(out.toByteArray());
     }
 


### PR DESCRIPTION
## 변경 사항
기존에 XSSFWorkbook를 close 하지 않아(XSSFWorkbook가 Closble을 상속받은 인터페이스의 구현체라 close를 해줘야 하나 봅니다.) 에러가 잡혀 close를 추가해주었습니다.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
