### PR TITLE
hotfix-check roleList empty when leaderJob is empty

### DIFF
--- a/src/main/java/peer/backend/dto/board/recruit/RecruitCreateRequest.java
+++ b/src/main/java/peer/backend/dto/board/recruit/RecruitCreateRequest.java
@@ -56,8 +56,9 @@ public class RecruitCreateRequest {
     }
 
     public List<String> getLeaderJob() {
-        if (this.roleList == null && this.leaderJob == null)
+        if ((this.roleList == null || this.roleList.isEmpty()) && this.leaderJob == null) {
             return Collections.emptyList();
+        }
         else if (this.roleList != null && !this.roleList.isEmpty() && this.leaderJob != null)
             return this.leaderJob;
         else


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
모집글 생성시 RoleList가 비어있을 때 leaderJob 할당을 무시하기 위하여
조건문에 RoleList.isEmpty를 추가하였습니다.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
