### PR TITLE
FIX: message bug

### DIFF
--- a/src/main/java/peer/backend/controller/message/MessaageController.java
+++ b/src/main/java/peer/backend/controller/message/MessaageController.java
@@ -65,13 +65,14 @@ public class MessaageController {
 
     @ApiOperation(value = "", notes = "유저의 쪽지 목록 중 일부를 삭제 한다.")
     @DeleteMapping("/delete-message")
-    public ResponseEntity<List<MsgObjectDTO>> deleteLetterList(Authentication auth, @RequestBody List<TargetForDelete>  body) {
+    public ResponseEntity<List<MsgObjectDTO>> deleteLetterList(Authentication auth, @RequestBody TargetDTO  body) {
         CompletableFuture<AsyncResult<Long>> deleted;
-        System.out.println(body.get(0).getTargetId());
+        System.out.println("오잉?!");
         deleted = this.messageMainService.deleteLetterList(User.authenticationToUser(auth).getId(), body);
         try {
             Long finished = deleted.get().getResult();
         } catch (Exception e) {
+            log.error("Error from delete message");
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
         AsyncResult<List<MsgObjectDTO>> wrappedRet;

--- a/src/main/java/peer/backend/dto/message/TargetForDelete.java
+++ b/src/main/java/peer/backend/dto/message/TargetForDelete.java
@@ -11,5 +11,5 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TargetForDelete {
-    private Long targetId;
+    private Long conversationId;
 }

--- a/src/main/java/peer/backend/repository/message/MessageIndexRepository.java
+++ b/src/main/java/peer/backend/repository/message/MessageIndexRepository.java
@@ -8,8 +8,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MessageIndexRepository extends JpaRepository<MessageIndex, Long> {
-    @Query("SELECT m FROM MessageIndex m WHERE (m.userIdx1 = :id1 AND m.userIdx2 = :id2) OR (m.userIdx1 = :id2 AND m.userIdx2 = :id1)")
-    Optional<MessageIndex> findByUserIdx(long id1, Long id2);
+    @Query("SELECT m FROM MessageIndex m WHERE (m.userIdx1 = :id1 AND m.userIdx2 = :id2 AND m.user1delete = false AND m.user2delete = false) OR (m.userIdx1 = :id2 AND m.userIdx2 = :id1 AND m.user1delete = false AND m.user2delete = false)")
+    Optional<MessageIndex> findByUserIdx(Long id1, Long id2);
 
     @Query("SELECT m FROM MessageIndex m WHERE (m.userIdx1 = :id OR m.userIdx2 = :id)")
     Optional<List<MessageIndex>> findByUserId(long id);

--- a/src/main/java/peer/backend/service/message/MessageMainService.java
+++ b/src/main/java/peer/backend/service/message/MessageMainService.java
@@ -108,27 +108,23 @@ public class MessageMainService {
      */
     @Async
     @Transactional
-    public CompletableFuture<AsyncResult<Long>> deleteLetterList(long userId, List<TargetForDelete> list){
+    public CompletableFuture<AsyncResult<Long>> deleteLetterList(long userId, TargetDTO list){
         Long ret;
         ret = 0L;
         Optional<List<MessageIndex>> rawTargetsData = this.indexRepository.findByUserId(userId);
         List<MessageIndex> targetData = rawTargetsData.orElseGet(() -> null);
         if (rawTargetsData.isEmpty())
             return CompletableFuture.completedFuture(AsyncResult.success(0L));
-        boolean check = false;
-//        List<TargetForDelete> targetUserIds = list;
-        for (TargetForDelete target : list) {
+        List<TargetForDelete> targetUserIds = list.getTarget();
+        for (TargetForDelete target : targetUserIds) {
             for (MessageIndex data : targetData) {
-                if (data.getUserIdx1().equals(target.getTargetId())) {
-                    data.setUser2delete(true);
-                    check = true;
-                }
-                if (data.getUserIdx2().equals(target.getTargetId())) {
-                    data.setUser1delete(true);
-                    check = true;
-                }
-                if (check) {
-                    check = false;
+                if (target.getConversationId().equals(data.getConversationId())) {
+                    if (data.getUserIdx1().equals(userId)) {
+                        data.setUser1delete(true);
+                    }
+                    if (data.getUserIdx2().equals(userId)) {
+                        data.setUser2delete(true);
+                    }
                     if (data.isUser1delete() && data.isUser2delete()) {
                         this.indexRepository.delete(data);
                         ret++;
@@ -137,7 +133,7 @@ public class MessageMainService {
                     else {
                         this.indexRepository.save(data);
                         ret++;
-                        break ;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## 문제 상황
- A, B가 대화중에 B가 대화를 삭제한다. 이때 A 혹은 B가 새롭게 대화를 동일한 상대와 하도록 메시지를 보내게 되면, 최초 메시지는 전달 됨. 그러나 이후 새로운 대화방 메시지 전달이 안됨. 
- 더불어 삭제도 정상적으로 처리 되지 않음 

## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- 프론트에서 conversationId 로 로직 변경된 것에 대응하여 DTO 수정 
- 이에 따라 삭제 비즈니스 로직의 삭제 로직 변경 -> 좀더 리펙토링이 필요해 보임 
- back-message api의 message index 를 요청하는 쿼리문 수정하여 삭제 되지 않은 메시지를 찾을 수 있도록 수정함. 

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
