### PR TITLE
[FEATURE] 어드민 알림 파트 유저, 팀 리스트, 검색 API 개발

### DIFF
--- a/src/main/java/peer/backend/controller/AdminController.java
+++ b/src/main/java/peer/backend/controller/AdminController.java
@@ -1,0 +1,26 @@
+package peer.backend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import peer.backend.dto.user.UserDefaultResponse;
+import peer.backend.entity.user.User;
+import peer.backend.service.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+
+    private final UserService userService;
+
+    @GetMapping("user")
+    public ResponseEntity<Page<UserDefaultResponse>> getUserDefaultList(Pageable pageable) {
+        Page<User> userList = this.userService.getUserListFromPageable(pageable);
+        return ResponseEntity.ok().body(userList.map(UserDefaultResponse::new));
+    }
+}

--- a/src/main/java/peer/backend/controller/AdminController.java
+++ b/src/main/java/peer/backend/controller/AdminController.java
@@ -5,8 +5,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import peer.backend.dto.KeywordRequest;
 import peer.backend.dto.user.UserDefaultResponse;
 import peer.backend.entity.user.User;
 import peer.backend.service.UserService;
@@ -21,6 +23,15 @@ public class AdminController {
     @GetMapping("user")
     public ResponseEntity<Page<UserDefaultResponse>> getUserDefaultList(Pageable pageable) {
         Page<User> userList = this.userService.getUserListFromPageable(pageable);
+        return ResponseEntity.ok().body(userList.map(UserDefaultResponse::new));
+    }
+
+    @GetMapping("user/nickname")
+    public ResponseEntity<Page<UserDefaultResponse>> searchUserDefaultListByNickname(
+        Pageable pageable,
+        @RequestBody KeywordRequest request) {
+        Page<User> userList = this.userService.searchUserListByNicknameFromPageable(pageable,
+            request.getKeyword());
         return ResponseEntity.ok().body(userList.map(UserDefaultResponse::new));
     }
 }

--- a/src/main/java/peer/backend/controller/AdminController.java
+++ b/src/main/java/peer/backend/controller/AdminController.java
@@ -1,5 +1,6 @@
 package peer.backend.controller;
 
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,7 +34,7 @@ public class AdminController {
     @GetMapping("user/nickname")
     public ResponseEntity<Page<UserDefaultResponse>> searchUserDefaultListByNickname(
         Pageable pageable,
-        @RequestBody KeywordRequest request) {
+        @RequestBody @Valid KeywordRequest request) {
         Page<User> userList = this.userService.searchUserListByNicknameFromPageable(pageable,
             request.getKeyword());
         return ResponseEntity.ok().body(userList.map(UserDefaultResponse::new));
@@ -42,6 +43,14 @@ public class AdminController {
     @GetMapping("team")
     public ResponseEntity<Page<TeamDefaultResponse>> getTeamDefaultList(Pageable pageable) {
         Page<Team> teamList = this.teamService.getTeamListFromPageable(pageable);
+        return ResponseEntity.ok().body(teamList.map(TeamDefaultResponse::new));
+    }
+
+    @GetMapping("team/name-leader")
+    public ResponseEntity<Page<TeamDefaultResponse>> searcTeamDefaultListByNameOrLeader(
+        Pageable pageable, @RequestBody @Valid KeywordRequest request) {
+        Page<Team> teamList = this.teamService.getTeamListByNameOrLeaderFromPageable(pageable,
+            request.getKeyword());
         return ResponseEntity.ok().body(teamList.map(TeamDefaultResponse::new));
     }
 }

--- a/src/main/java/peer/backend/controller/AdminController.java
+++ b/src/main/java/peer/backend/controller/AdminController.java
@@ -9,9 +9,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import peer.backend.dto.KeywordRequest;
+import peer.backend.dto.team.TeamDefaultResponse;
 import peer.backend.dto.user.UserDefaultResponse;
+import peer.backend.entity.team.Team;
 import peer.backend.entity.user.User;
 import peer.backend.service.UserService;
+import peer.backend.service.team.TeamService;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +22,7 @@ import peer.backend.service.UserService;
 public class AdminController {
 
     private final UserService userService;
+    private final TeamService teamService;
 
     @GetMapping("user")
     public ResponseEntity<Page<UserDefaultResponse>> getUserDefaultList(Pageable pageable) {
@@ -33,5 +37,11 @@ public class AdminController {
         Page<User> userList = this.userService.searchUserListByNicknameFromPageable(pageable,
             request.getKeyword());
         return ResponseEntity.ok().body(userList.map(UserDefaultResponse::new));
+    }
+
+    @GetMapping("team")
+    public ResponseEntity<Page<TeamDefaultResponse>> getTeamDefaultList(Pageable pageable) {
+        Page<Team> teamList = this.teamService.getTeamListFromPageable(pageable);
+        return ResponseEntity.ok().body(teamList.map(TeamDefaultResponse::new));
     }
 }

--- a/src/main/java/peer/backend/dto/KeywordRequest.java
+++ b/src/main/java/peer/backend/dto/KeywordRequest.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class KeywordDTO {
+public class KeywordRequest {
 
     @NotBlank(message = "키워드가 비어있습니다!")
     private String keyword;

--- a/src/main/java/peer/backend/dto/team/TeamDefaultResponse.java
+++ b/src/main/java/peer/backend/dto/team/TeamDefaultResponse.java
@@ -1,0 +1,32 @@
+package peer.backend.dto.team;
+
+import lombok.Getter;
+import peer.backend.dto.user.UserDefaultResponse;
+import peer.backend.entity.team.Team;
+import peer.backend.entity.team.TeamUser;
+import peer.backend.entity.team.enums.TeamStatus;
+import peer.backend.entity.team.enums.TeamType;
+import peer.backend.entity.team.enums.TeamUserRoleType;
+
+@Getter
+public class TeamDefaultResponse {
+
+    private final Long teamId;
+    private final TeamType teamType;
+    private final String name;
+    private final TeamStatus teamStatus;
+    private UserDefaultResponse leader;
+
+    public TeamDefaultResponse(Team team) {
+        this.teamId = team.getId();
+        this.teamType = team.getType();
+        this.name = team.getName();
+        this.teamStatus = team.getStatus();
+        for (TeamUser tu : team.getTeamUsers()) {
+            if (tu.getRole().equals(TeamUserRoleType.LEADER)) {
+                this.leader = new UserDefaultResponse(tu.getUser());
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/peer/backend/dto/user/UserDefaultResponse.java
+++ b/src/main/java/peer/backend/dto/user/UserDefaultResponse.java
@@ -1,0 +1,20 @@
+package peer.backend.dto.user;
+
+import lombok.Getter;
+import peer.backend.entity.user.User;
+
+@Getter
+public class UserDefaultResponse {
+
+    private final Long userId;
+    private final String nickname;
+    private final String email;
+    private final String name;
+
+    public UserDefaultResponse(User user) {
+        this.userId = user.getId();
+        this.nickname = user.getNickname();
+        this.email = user.getEmail();
+        this.name = user.getName();
+    }
+}

--- a/src/main/java/peer/backend/repository/team/TeamRepository.java
+++ b/src/main/java/peer/backend/repository/team/TeamRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import peer.backend.entity.team.Team;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
+
     Optional<Team> findByName(String name);
 }

--- a/src/main/java/peer/backend/repository/team/TeamRepository.java
+++ b/src/main/java/peer/backend/repository/team/TeamRepository.java
@@ -1,10 +1,16 @@
 package peer.backend.repository.team;
 
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import peer.backend.entity.team.Team;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
     Optional<Team> findByName(String name);
+
+    @Query(value = "SELECT t.* FROM team t INNER JOIN team_user tu ON t.id = tu.team_id INNER JOIN user u ON tu.user_id = u.id WHERE t.name LIKE CONCAT('%', :keyword, '%') OR (tu.role = 'LEADER' AND u.nickname LIKE CONCAT('%', :keyword, '%'))", countQuery = "SELECT count(t) FROM Team t", nativeQuery = true)
+    Page<Team> findByNameAndLeaderContainingFromPageable(Pageable pageable, String keyword);
 }

--- a/src/main/java/peer/backend/repository/user/UserRepository.java
+++ b/src/main/java/peer/backend/repository/user/UserRepository.java
@@ -1,5 +1,7 @@
 package peer.backend.repository.user;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import peer.backend.entity.user.User;
@@ -24,4 +26,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<List<User>> findByEmailOrNickname(String email, String nickname);
 
     boolean existsByEmail(String email);
+
+    @Query(value = "SELECT u FROM User u WHERE u.nickname LIKE %:keyword%", countQuery = "SELECT count(w) FROM Wallet w")
+    Page<User> findByNicknameContainingFromPageable(Pageable pageable, String keyword);
 }

--- a/src/main/java/peer/backend/repository/user/UserRepository.java
+++ b/src/main/java/peer/backend/repository/user/UserRepository.java
@@ -27,6 +27,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
-    @Query(value = "SELECT u FROM User u WHERE u.nickname LIKE %:keyword%", countQuery = "SELECT count(w) FROM Wallet w")
+    @Query(value = "SELECT u FROM User u WHERE u.nickname LIKE %:keyword%", countQuery = "SELECT count(u) FROM User u")
     Page<User> findByNicknameContainingFromPageable(Pageable pageable, String keyword);
 }

--- a/src/main/java/peer/backend/service/UserService.java
+++ b/src/main/java/peer/backend/service/UserService.java
@@ -32,4 +32,8 @@ public class UserService {
     public Page<User> getUserListFromPageable(Pageable pageable) {
         return this.userRepository.findAll(pageable);
     }
+
+    public Page<User> searchUserListByNicknameFromPageable(Pageable pageable, String keyword) {
+        return this.userRepository.findByNicknameContainingFromPageable(pageable, keyword);
+    }
 }

--- a/src/main/java/peer/backend/service/UserService.java
+++ b/src/main/java/peer/backend/service/UserService.java
@@ -2,6 +2,8 @@ package peer.backend.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import peer.backend.entity.user.User;
 import peer.backend.exception.NotFoundException;
@@ -27,4 +29,7 @@ public class UserService {
             .orElseThrow(() -> new NotFoundException("존재하지 않은 유저입니다."));
     }
 
+    public Page<User> getUserListFromPageable(Pageable pageable) {
+        return this.userRepository.findAll(pageable);
+    }
 }

--- a/src/main/java/peer/backend/service/team/TeamService.java
+++ b/src/main/java/peer/backend/service/team/TeamService.java
@@ -320,4 +320,9 @@ public class TeamService {
     public Page<Team> getTeamListFromPageable(Pageable pageable) {
         return this.teamRepository.findAll(pageable);
     }
+
+    @Transactional
+    public Page<Team> getTeamListByNameOrLeaderFromPageable(Pageable pageable, String keyword) {
+        return this.teamRepository.findByNameAndLeaderContainingFromPageable(pageable, keyword);
+    }
 }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
어드민 알림 관리 페이지에서 사용하기 위한 유저, 팀 기본 정보 리스트와 닉네임을 통한 유저 검색, 팀 이름 or 팀장 닉네임을 통한 팀 검색을 구현하였습니다.

#537 
- 유저 기본 정보 리스트
    - https://github.com/orgs/peer-42seoul/projects/35/views/1?pane=issue&itemId=48564436
- 닉네임으로 유저 기본 정보 검색
    - https://github.com/orgs/peer-42seoul/projects/35/views/1?pane=issue&itemId=48565636
- 팀 기본 정보 리스트
    - https://github.com/orgs/peer-42seoul/projects/35/views/1?pane=issue&itemId=48566162
- 팀 명 or 팀장 닉네임으로 팀 기본 정보 검색
    - https://github.com/orgs/peer-42seoul/projects/35/views/1?pane=issue&itemId=48566492


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
