### PR TITLE
[Hotfix] team memeber handling

### DIFF
--- a/src/main/java/peer/backend/dto/board/recruit/RecruitCreateRequest.java
+++ b/src/main/java/peer/backend/dto/board/recruit/RecruitCreateRequest.java
@@ -9,6 +9,7 @@ import peer.backend.entity.team.enums.TeamType;
 import peer.backend.exception.IllegalArgumentException;
 
 import javax.persistence.Lob;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;

--- a/src/main/java/peer/backend/dto/team/TeamApplicantListDto.java
+++ b/src/main/java/peer/backend/dto/team/TeamApplicantListDto.java
@@ -5,8 +5,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import peer.backend.dto.board.recruit.RecruitAnswerDto;
+import peer.backend.entity.composite.TeamUserJobPK;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,5 +17,6 @@ import java.util.ArrayList;
 public class TeamApplicantListDto {
     String name;
     Long userId;
-    ArrayList<RecruitAnswerDto> answers;
+    TeamUserJobPK applyId;
+    List<RecruitAnswerDto> answers;
 }

--- a/src/main/java/peer/backend/dto/team/TeamSettingDto.java
+++ b/src/main/java/peer/backend/dto/team/TeamSettingDto.java
@@ -3,6 +3,7 @@ package peer.backend.dto.team;
 import lombok.Getter;
 import peer.backend.entity.team.Team;
 import peer.backend.entity.team.TeamUser;
+import peer.backend.entity.team.enums.TeamUserStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +17,8 @@ public class TeamSettingDto {
         this.team = new TeamSettingInfoDto(team);
         this.member = new ArrayList<>();
         for (TeamUser teamUser: teamUserList) {
-            this.member.add(new TeamMemberDto(teamUser));
+            if (teamUser.getStatus().equals(TeamUserStatus.APPROVED))
+                this.member.add(new TeamMemberDto(teamUser));
         }
     }
 }

--- a/src/main/java/peer/backend/entity/team/Team.java
+++ b/src/main/java/peer/backend/entity/team/Team.java
@@ -42,6 +42,7 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private RecruitDueEnum dueTo;
+    @Column
     private int dueValue;
 
     @Column()
@@ -131,7 +132,6 @@ public class Team extends BaseEntity {
         if (this.dueTo != null) {
             this.dueValue = this.dueTo.getValue();
         }
-        this.maxMember = (this.getJobs() == null ? null:  this.getJobs().stream().mapToInt(TeamJob::getMax).sum());
     }
 
     public boolean deleteTeamUser(Long deletingToUserId) {

--- a/src/main/java/peer/backend/entity/team/TeamUser.java
+++ b/src/main/java/peer/backend/entity/team/TeamUser.java
@@ -47,9 +47,6 @@ public class TeamUser {
     @OneToMany(mappedBy = "teamUser", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TeamUserJob> teamUserJobs;
 
-    @ElementCollection
-    private List<String> answers;
-
     @Column
     @Enumerated(EnumType.STRING)
     private TeamUserStatus status;
@@ -57,12 +54,14 @@ public class TeamUser {
     public void grantLeader(TeamUserRoleType teamUserRoleType) {
         this.role = teamUserRoleType;
     }
+    public void grantMember(){
+        this.status = TeamUserStatus.APPROVED;
+    }
 
     public void addTeamUserJob(TeamUserJob teamUserJob) {
         if (teamUserJobs == null) {
             teamUserJobs = new ArrayList<>();
         }
-
         teamUserJobs.add(teamUserJob);
     }
 }

--- a/src/main/java/peer/backend/entity/team/TeamUser.java
+++ b/src/main/java/peer/backend/entity/team/TeamUser.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import peer.backend.entity.team.enums.TeamUserRoleType;
+import peer.backend.entity.team.enums.TeamUserStatus;
 import peer.backend.entity.user.User;
 
 import javax.persistence.*;
@@ -48,6 +49,10 @@ public class TeamUser {
 
     @ElementCollection
     private List<String> answers;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private TeamUserStatus status;
 
     public void grantLeader(TeamUserRoleType teamUserRoleType) {
         this.role = teamUserRoleType;

--- a/src/main/java/peer/backend/entity/team/TeamUserJob.java
+++ b/src/main/java/peer/backend/entity/team/TeamUserJob.java
@@ -5,6 +5,7 @@ import peer.backend.entity.composite.TeamUserJobPK;
 import peer.backend.entity.team.enums.TeamUserStatus;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -37,7 +38,11 @@ public class TeamUserJob {
     @Column
     private TeamUserStatus status;
 
+    @ElementCollection
+    private List<String> answers;
+
     public void acceptApplicant(){
         this.status = TeamUserStatus.APPROVED;
+        this.getTeamUser().grantMember();
     }
 }

--- a/src/main/java/peer/backend/repository/team/TeamUserJobRepository.java
+++ b/src/main/java/peer/backend/repository/team/TeamUserJobRepository.java
@@ -3,13 +3,18 @@ package peer.backend.repository.team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import peer.backend.entity.composite.TeamUserJobPK;
+import peer.backend.entity.team.Team;
 import peer.backend.entity.team.TeamUserJob;
 import peer.backend.entity.team.enums.TeamUserStatus;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamUserJobRepository extends JpaRepository<TeamUserJob, TeamUserJobPK> {
 
     @Query("SELECT tuj FROM TeamUserJob tuj WHERE tuj.teamUser.teamId = :teamId AND tuj.status = :status")
-    public List<TeamUserJob> findByTeamUserTeamIdAndStatus(Long teamId, TeamUserStatus status);
+    List<TeamUserJob> findByTeamUserTeamIdAndStatus(Long teamId, TeamUserStatus status);
+
+    @Query("SELECT tuj FROM TeamUserJob tuj WHERE tuj.teamJob.team = :teamId AND tuj.status = :status")
+    List<TeamUserJob> findByTeamJobTeamIdAndStatus(Team team, TeamUserStatus status);
 }

--- a/src/main/java/peer/backend/repository/team/TeamUserRepository.java
+++ b/src/main/java/peer/backend/repository/team/TeamUserRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import peer.backend.entity.team.TeamUser;
 import peer.backend.entity.team.enums.TeamUserRoleType;
+import peer.backend.entity.team.enums.TeamUserStatus;
 
 import java.util.List;
 
@@ -16,6 +17,9 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
     List<TeamUser> findByTeamId(Long teamId);
 
     Boolean existsByUserIdAndTeamId(Long userId, Long teamId);
+
+    List<TeamUser> findByTeamIdAndStatus(Long teamId, TeamUserStatus status);
+    Boolean existsByUserIdAndTeamIdAndStatus(Long userId, Long teamId, TeamUserStatus status);
 
     @Query("select t.role from TeamUser t where t.teamId = :teamId and t.userId = :userId")
     TeamUserRoleType findTeamUserRoleTypeByTeamIdAndUserId(Long teamId, Long userId);

--- a/src/main/java/peer/backend/service/team/TeamService.java
+++ b/src/main/java/peer/backend/service/team/TeamService.java
@@ -257,9 +257,11 @@ public class TeamService {
     public List<TeamMemberDto> getTeamMemberList(Long teamId, User user) {
         Team team = this.teamRepository.findById(teamId)
             .orElseThrow(() -> new NotFoundException("팀이 없습니다"));
-        if (teamUserRepository.existsByUserIdAndTeamId(user.getId(), teamId)) {
-            return team.getTeamUsers().stream().map(TeamMemberDto::new)
-                .collect(Collectors.toList());
+        if (teamUserRepository.existsByUserIdAndTeamIdAndStatus(user.getId(), teamId, TeamUserStatus.APPROVED)) {
+            return teamUserRepository.findByTeamIdAndStatus(teamId, TeamUserStatus.APPROVED)
+                    .stream()
+                    .map(TeamMemberDto::new)
+                    .collect(Collectors.toList());
         } else {
             throw new ForbiddenException("팀에 속해있지 않습니다.");
         }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
* team Member의 다중 신청 및 관리를 위하여 teamUser에 Status 추가
* team 생성시 type이 study인 경우 STUDY로 teamJob을 STUDY로 생성하여 신청자를 관리
* type이 study인 팀에 신청시 teamUserJob을 STUDY인 teamJob으로 연결하여 생성
* team setting값 조회시 approve된 멤버만 포함
* 다중신청을 위해 answers는 teamUserJob쪽으로 이동
* 기타 관련 마이너한 수정사항

추후 로직 리팩토링 필요할 듯...
코드스멜 엄청날 것 같아서 두려움


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
