### PR TITLE
FIX: getTeamInfo API add validation checker

### DIFF
--- a/src/main/java/peer/backend/controller/team/TeamController.java
+++ b/src/main/java/peer/backend/controller/team/TeamController.java
@@ -96,6 +96,7 @@ public class TeamController {
         return this.teamService.getTeamApplicantList(teamId, thisUser);
     }
 
+    //TODO: need validator
     @GetMapping("/main/{teamId}")
     public TeamInfoResponse getTeamInfo(@PathVariable() Long teamId, Authentication authentication) {
         User user = User.authenticationToUser(authentication);

--- a/src/main/java/peer/backend/controller/team/TeamController.java
+++ b/src/main/java/peer/backend/controller/team/TeamController.java
@@ -96,7 +96,6 @@ public class TeamController {
         return this.teamService.getTeamApplicantList(teamId, thisUser);
     }
 
-    //TODO: need validator
     @GetMapping("/main/{teamId}")
     public TeamInfoResponse getTeamInfo(@PathVariable() Long teamId, Authentication authentication) {
         User user = User.authenticationToUser(authentication);

--- a/src/main/java/peer/backend/repository/team/TeamUserRepository.java
+++ b/src/main/java/peer/backend/repository/team/TeamUserRepository.java
@@ -16,6 +16,8 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 
     List<TeamUser> findByTeamId(Long teamId);
 
+    @Query("select count(t) > 0 from TeamUser t where t.teamId = :teamId and t.userId = :userId and t.status = 'APPROVED'")
+    Boolean existsAndMemberByUserIdAndTeamId(Long userId, Long teamId);
     Boolean existsByUserIdAndTeamId(Long userId, Long teamId);
 
     List<TeamUser> findByTeamIdAndStatus(Long teamId, TeamUserStatus status);

--- a/src/main/java/peer/backend/service/team/TeamService.java
+++ b/src/main/java/peer/backend/service/team/TeamService.java
@@ -259,13 +259,20 @@ public class TeamService {
 
     @Transactional
     public TeamInfoResponse getTeamInfo(Long teamId, User user) {
+//        Team team = this.teamRepository.findById(teamId)
+//            .orElseThrow(() -> new NotFoundException("팀이 없습니다"));
+//        if (teamUserRepository.existsByUserIdAndTeamId(user.getId(), teamId)) {
+//            if (checkValidationForApprovedOrNot(user, team))
+//                return new TeamInfoResponse(team);
+//            else
+//                throw new UnauthorizedException("팀 멤버로 승인되어 있지 않습니다.");
+//        } else {
+//            throw new ForbiddenException("팀에 속해있지 않습니다.");
+//        }
         Team team = this.teamRepository.findById(teamId)
-            .orElseThrow(() -> new NotFoundException("팀이 없습니다"));
-        if (teamUserRepository.existsByUserIdAndTeamId(user.getId(), teamId)) {
-            if (checkValidationForApprovedOrNot(user, team))
-                return new TeamInfoResponse(team);
-            else
-                throw new UnauthorizedException("팀 멤버로 승인되어 있지 않습니다.");
+                .orElseThrow(() -> new NotFoundException("팀이 없습니다"));
+        if (teamUserRepository.existsAndMemberByUserIdAndTeamId(user.getId(), teamId)) {
+            return new TeamInfoResponse(team);
         } else {
             throw new ForbiddenException("팀에 속해있지 않습니다.");
         }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- 실제 유저가 APPROVED 되어 있는가 확인하는 validation checker 메서드를 추가하였습니다. 
- `팀 메인 페이지에서 팀 정보 불러오기` API에 해당 메서드를 적용하여, APPROVED 되지 않으면 데이터를 전달하지 않는 것으로 수정


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
- Postman 을 통해 401이 정상적으로 나오는지 점검 완료