### PR TITLE
FIX: profile input error

### DIFF
--- a/src/main/java/peer/backend/annotation/CustomSize.java
+++ b/src/main/java/peer/backend/annotation/CustomSize.java
@@ -1,0 +1,19 @@
+package peer.backend.annotation;
+
+import peer.backend.validator.LineBreakNormalizerValidator;
+
+import java.lang.annotation.*;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = LineBreakNormalizerValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomSize {
+    String message() default "Line breaks normalized";
+    int min() default 0;
+    int max() default Integer.MAX_VALUE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/peer/backend/annotation/OnlyEngKorNum.java
+++ b/src/main/java/peer/backend/annotation/OnlyEngKorNum.java
@@ -1,0 +1,17 @@
+package peer.backend.annotation;
+
+import peer.backend.validator.OnlyEngKorNumValidator;
+
+import java.lang.annotation.*;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = OnlyEngKorNumValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OnlyEngKorNum {
+    String message() default "Only English, Korean, and numbers are allowed";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/peer/backend/controller/profile/ProfileController.java
+++ b/src/main/java/peer/backend/controller/profile/ProfileController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import peer.backend.annotation.OnlyEngKorNum;
 import peer.backend.dto.profile.request.EditProfileRequest;
 import peer.backend.dto.profile.request.LinkListRequest;
 import peer.backend.dto.profile.response.NicknameResponse;
@@ -50,7 +51,7 @@ public class ProfileController {
 
     @ApiOperation(value = "", notes = "닉네임 중복 확인하기.")
     @PostMapping("/signup/nickname") // "/membership/nickname/check" 로 테스트 진행 했음
-    public ResponseEntity<Object> isExistNickname(@RequestBody NicknameResponse nickname) {
+    public ResponseEntity<Object> isExistNickname(@RequestBody @Valid NicknameResponse nickname) {
         if (profileService.isExistNickname(nickname.getNickname())) {
             throw new ConflictException("이미 사용 중인 닉네임입니다.");
         }

--- a/src/main/java/peer/backend/controller/profile/ProfileController.java
+++ b/src/main/java/peer/backend/controller/profile/ProfileController.java
@@ -99,27 +99,6 @@ public class ProfileController {
     @PutMapping("/profile/introduction/edit")
     public ResponseEntity<Object> editProfile(Authentication auth,
         @ModelAttribute @Valid EditProfileRequest profile) throws IOException {
-        if (profile.getNickname().isEmpty() || profile.getNickname().isBlank()) {
-            throw new BadRequestException("닉네임은 반드시 입력해야 합니다.");
-        }
-        else if (profile.getNickname().length() > 7 || profile.getNickname().length() < 2) {
-            throw new BadRequestException("닉네임은 2자 이상, 7자 이하여야 합니다.");
-        }
-//        String str = profile.getIntroduction();
-//        int total = str.length();
-//        int lineBreakerLength = 0;
-//
-//        for (int i = 0; i < str.length(); i++) {
-//            if (str.charAt(i) == '\r')
-//                lineBreakerLength++;
-//            i++;
-//        }
-//
-//        System.out.println("실제 길이 사이즈 : " + profile.getIntroduction().length());
-//        System.out.println("개행 길이 사이즈 : " + lineBreakerLength);
-//        if (profile.getIntroduction() != null && profile.getIntroduction().length() - lineBreakerLength > 150) {
-//            throw new BadRequestException("자기소개는 150자 이내여야 합니다.");
-//        }
         profileService.editProfile(auth, profile, convertBoolean(profile.getImageChange()));
         return new ResponseEntity<>(HttpStatus.CREATED);
     }

--- a/src/main/java/peer/backend/controller/profile/ProfileController.java
+++ b/src/main/java/peer/backend/controller/profile/ProfileController.java
@@ -105,9 +105,21 @@ public class ProfileController {
         else if (profile.getNickname().length() > 7 || profile.getNickname().length() < 2) {
             throw new BadRequestException("닉네임은 2자 이상, 7자 이하여야 합니다.");
         }
-        if (profile.getIntroduction() != null && profile.getIntroduction().length() > 150) {
-            throw new BadRequestException("자기소개는 150자 이내여야 합니다.");
-        }
+//        String str = profile.getIntroduction();
+//        int total = str.length();
+//        int lineBreakerLength = 0;
+//
+//        for (int i = 0; i < str.length(); i++) {
+//            if (str.charAt(i) == '\r')
+//                lineBreakerLength++;
+//            i++;
+//        }
+//
+//        System.out.println("실제 길이 사이즈 : " + profile.getIntroduction().length());
+//        System.out.println("개행 길이 사이즈 : " + lineBreakerLength);
+//        if (profile.getIntroduction() != null && profile.getIntroduction().length() - lineBreakerLength > 150) {
+//            throw new BadRequestException("자기소개는 150자 이내여야 합니다.");
+//        }
         profileService.editProfile(auth, profile, convertBoolean(profile.getImageChange()));
         return new ResponseEntity<>(HttpStatus.CREATED);
     }

--- a/src/main/java/peer/backend/dto/profile/request/EditProfileRequest.java
+++ b/src/main/java/peer/backend/dto/profile/request/EditProfileRequest.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 import peer.backend.annotation.CustomSize;
+import peer.backend.annotation.OnlyEngKorNum;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -14,7 +15,8 @@ public class EditProfileRequest {
     private MultipartFile profileImage;
     private String imageChange;
     @NotNull(message = "닉네임은 반드시 입력해야 합니다.")
-    @Size(min = 2, max = 30, message = "닉네임은 최소 2자, 최대 30자까지 입력 가능합니다.")
+    @CustomSize(min = 2, max = 30, message = "닉네임은 최소 2자, 최대 30자까지 입력 가능합니다.")
+    @OnlyEngKorNum(message = "반드시, 영어, 한글, 숫자로만 닉네임을 설정해주셔야 합니다.")
     private String nickname;
     @CustomSize(min = 0, max = 150, message = "자기 소개문은 최대 150자까지 입력 가능합니다.")
     private String introduction;

--- a/src/main/java/peer/backend/dto/profile/request/EditProfileRequest.java
+++ b/src/main/java/peer/backend/dto/profile/request/EditProfileRequest.java
@@ -3,6 +3,7 @@ package peer.backend.dto.profile.request;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
+import peer.backend.annotation.CustomSize;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -15,6 +16,6 @@ public class EditProfileRequest {
     @NotNull(message = "닉네임은 반드시 입력해야 합니다.")
     @Size(min = 2, max = 30, message = "닉네임은 최소 2자, 최대 30자까지 입력 가능합니다.")
     private String nickname;
-    @Size(min = 0, max = 150, message = "자기 소개글은 최대 150자까지만 입력 가능합니다.")
+    @CustomSize(min = 0, max = 150, message = "자기 소개문은 최대 150자까지 입력 가능합니다.")
     private String introduction;
 }

--- a/src/main/java/peer/backend/dto/profile/response/NicknameResponse.java
+++ b/src/main/java/peer/backend/dto/profile/response/NicknameResponse.java
@@ -1,8 +1,12 @@
 package peer.backend.dto.profile.response;
 
 import lombok.Getter;
+import peer.backend.annotation.CustomSize;
+import peer.backend.annotation.OnlyEngKorNum;
 
 @Getter
 public class NicknameResponse {
+    @OnlyEngKorNum(message = "반드시, 영어, 한글, 숫자로만 닉네임을 설정해주셔야 합니다.")
+    @CustomSize(min = 2, max = 30, message = "닉네임은 최소 2자, 최대 30자까지 입력 가능합니다.")
     private String nickname;
 }

--- a/src/main/java/peer/backend/validator/LineBreakNormalizerValidator.java
+++ b/src/main/java/peer/backend/validator/LineBreakNormalizerValidator.java
@@ -1,0 +1,31 @@
+package peer.backend.validator;
+
+import peer.backend.annotation.CustomSize;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class LineBreakNormalizerValidator implements ConstraintValidator<CustomSize, String> {
+    private int min;
+    private int max;
+    @Override
+    public void initialize(CustomSize constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value,  ConstraintValidatorContext context) {
+        if (value == null) {
+            return true; // null 값은 다른 방식으로 처리
+        }
+        // 유효성 검사 대신 문자열 변환 로직만 적용
+        int lineBreakerSize = 0;
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) == '\r')
+                lineBreakerSize++;
+        }
+        int valueLength = value.length() - lineBreakerSize;
+        return (valueLength >= min && valueLength <= max);
+    }
+}

--- a/src/main/java/peer/backend/validator/OnlyEngKorNumValidator.java
+++ b/src/main/java/peer/backend/validator/OnlyEngKorNumValidator.java
@@ -1,0 +1,21 @@
+package peer.backend.validator;
+
+import peer.backend.annotation.OnlyEngKorNum;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class OnlyEngKorNumValidator implements ConstraintValidator<OnlyEngKorNum, String> {
+
+    @Override
+    public void initialize(OnlyEngKorNum constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+        return value.matches("^[a-zA-Z가-힣0-9]+$");
+    }
+}


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
### 문제 파악 
- RestAPI 에서 사용하는 문자열 처리 방식은 ASCI 가 아닌 unicode 방식이다. 
- 그리고 개행문자의 경우 특수하게도 보여지기엔 한 글자로 처리 되지만 내부적으로 2글자로 처리 된다. 따라서 기존의 유효성 검사 방식으로는 안된다. 이에 이를 따로 파악하는 유효성 검사도구를 만들어야 한다. 
- 그렇기에 다양한 방법을 고려하다가 커스텀 어노테이션 쪽으로 확정을 잡음. 

### 해결 사항
- 기존에 사용하던 유효성 검사는 삭제함. 
- CustomSize 어노테이션 생성 및 Validator 생성 
- 닉네임 쪽도 해당 관련하여 영어, 숫자, 한글만 들어갈 수 있도록 하였으며 커스텀 어노테이션 적용 완료
- 닉네임 중복 검사 쪽 유효성 검사 추가 


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
실제 서비스로 테스트 완료 
