### PR TITLE
[Fix] : startWithPageNum one and posts order adding desc #608

### DIFF
--- a/src/main/java/peer/backend/controller/team/TeamPageController.java
+++ b/src/main/java/peer/backend/controller/team/TeamPageController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -34,7 +35,8 @@ public class TeamPageController {
     @ApiOperation(value = "TEAM-PAGE", notes = "특정 게시판 글 목록을 가져옵니다.")
     @GetMapping("/posts/{boardId}")
     public ResponseEntity<BoardRes> getPosts(@PathVariable("boardId") Long boardId, Pageable pageable) {
-        Page<PostRes> postsPage = teamPageService.getPostsByBoardId(boardId, pageable);
+        Pageable pageReq = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize());
+        Page<PostRes> postsPage = teamPageService.getPostsByBoardId(boardId, pageReq);
 
         if (!postsPage.isEmpty()) {
             Board board = boardService.getBoardById(boardId);
@@ -48,7 +50,8 @@ public class TeamPageController {
     @ApiOperation(value = "TEAM-PAGE", notes = "특정 게시판에 검색된 글 목록을 가져옵니다.")
     @GetMapping("/posts/search/{boardId}")
     public ResponseEntity<BoardRes> getPostsByKeyword(@PathVariable("boardId") Long boardId, Pageable pageable, @RequestParam(value = "keyword") String keyword) {
-        Page<PostRes> postsPage = teamPageService.getPostsByBoardIdWithKeyword(boardId, pageable, keyword);
+        Pageable pageReq = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize());
+        Page<PostRes> postsPage = teamPageService.getPostsByBoardIdWithKeyword(boardId, pageReq, keyword);
 
         if (!postsPage.isEmpty()) {
             Board board = boardService.getBoardById(boardId);

--- a/src/main/java/peer/backend/repository/board/team/PostRepository.java
+++ b/src/main/java/peer/backend/repository/board/team/PostRepository.java
@@ -16,6 +16,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findPostsByBoardOrderByIdDesc(Long boardId, Pageable pageable);
 
 
-    @Query("SELECT p FROM Post p WHERE p.board.id = :boardId AND (p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%'))")
+    @Query("SELECT p FROM Post p WHERE p.board.id = :boardId AND (p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%')) ORDER BY p.id DESC")
     Page<Post> findByBoardIdAndTitleOrContentContaining(Long boardId, String keyword, Pageable pageable);
 }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->

page 시작은 디폴트가 0,
1부터 시작하면 클라이언트 작업에 혼선을 예방 기대
포스트 출력이 최신순으로 반환되어야 해서 누락된 로직을 교정하였습니다.
<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
