### PR TITLE
[Feat] showcase api

### DIFF
--- a/src/main/java/peer/backend/config/SecurityConfig.java
+++ b/src/main/java/peer/backend/config/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
             .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/recruit/*")
             .permitAll()
-            .antMatchers(HttpMethod.GET, "/api/v1/showcase/*")
+            .antMatchers(HttpMethod.GET, "/api/v1/showcase/*", "/api/v1/showcase")
             .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/profile/other")
             .permitAll()

--- a/src/main/java/peer/backend/config/SecurityConfig.java
+++ b/src/main/java/peer/backend/config/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
             .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/recruit/*")
             .permitAll()
-            .antMatchers(HttpMethod.GET, "/api/v1/showcase")
+            .antMatchers(HttpMethod.GET, "/api/v1/showcase/*")
             .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/profile/other")
             .permitAll()

--- a/src/main/java/peer/backend/controller/board/ShowcaseController.java
+++ b/src/main/java/peer/backend/controller/board/ShowcaseController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import peer.backend.dto.board.team.ShowcaseListResponse;
+import peer.backend.dto.board.team.ShowcaseResponse;
 import peer.backend.service.board.team.ShowcaseService;
 
 @RestController
@@ -30,6 +31,11 @@ public class ShowcaseController {
     @PostMapping("like/{id}")
     public int doLike(@PathVariable Long id, Authentication auth){
         return showcaseService.doLike(id, auth);
+    }
+
+    @GetMapping("/{showcaseId}")
+    public ShowcaseResponse getShowcase(@PathVariable Long showcaseId, Authentication auth){
+        showcaseService.getShowcase(showcaseId, auth);
     }
 
 }

--- a/src/main/java/peer/backend/controller/board/ShowcaseController.java
+++ b/src/main/java/peer/backend/controller/board/ShowcaseController.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import peer.backend.dto.board.team.ShowcaseListResponse;
 import peer.backend.dto.board.team.ShowcaseResponse;
+import peer.backend.dto.board.team.ShowcaseWriteResponse;
 import peer.backend.service.board.team.ShowcaseService;
 
 @RestController
@@ -28,14 +29,19 @@ public class ShowcaseController {
         return showcaseService.doFavorite(id, auth);
     }
 
-    @PostMapping("like/{id}")
+    @PostMapping("/like/{id}")
     public int doLike(@PathVariable Long id, Authentication auth){
         return showcaseService.doLike(id, auth);
     }
 
     @GetMapping("/{showcaseId}")
     public ShowcaseResponse getShowcase(@PathVariable Long showcaseId, Authentication auth){
-        showcaseService.getShowcase(showcaseId, auth);
+        return showcaseService.getShowcase(showcaseId, auth);
+    }
+
+    @GetMapping("/{teamId}")
+    public ShowcaseWriteResponse getTeamInfoForCreateShowcase(@PathVariable Long teamId, Authentication auth){
+        return showcaseService.getTeamInfoForCreateShowcase(teamId, auth);
     }
 
 }

--- a/src/main/java/peer/backend/controller/board/ShowcaseController.java
+++ b/src/main/java/peer/backend/controller/board/ShowcaseController.java
@@ -3,12 +3,17 @@ package peer.backend.controller.board;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import peer.backend.dto.board.team.ShowcaseCreateDto;
 import peer.backend.dto.board.team.ShowcaseListResponse;
 import peer.backend.dto.board.team.ShowcaseResponse;
 import peer.backend.dto.board.team.ShowcaseWriteResponse;
 import peer.backend.service.board.team.ShowcaseService;
+
+import javax.validation.Valid;
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,9 +44,14 @@ public class ShowcaseController {
         return showcaseService.getShowcase(showcaseId, auth);
     }
 
-    @GetMapping("/{teamId}")
+    @GetMapping("/write/{teamId}")
     public ShowcaseWriteResponse getTeamInfoForCreateShowcase(@PathVariable Long teamId, Authentication auth){
         return showcaseService.getTeamInfoForCreateShowcase(teamId, auth);
+    }
+
+    @PostMapping("/write")
+    public Long createShowcase(@RequestBody @Valid ShowcaseCreateDto request, Authentication auth) {
+        return showcaseService.createShowcase(request, auth);
     }
 
 }

--- a/src/main/java/peer/backend/dto/board/team/BoardCreateRequest.java
+++ b/src/main/java/peer/backend/dto/board/team/BoardCreateRequest.java
@@ -1,11 +1,15 @@
 package peer.backend.dto.board.team;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import peer.backend.entity.board.team.enums.BoardType;
 
 @Getter
 @RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
 public class BoardCreateRequest {
     private Long teamId;
     private String name;

--- a/src/main/java/peer/backend/dto/board/team/PostLinkResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/PostLinkResponse.java
@@ -1,0 +1,13 @@
+package peer.backend.dto.board.team;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class PostLinkResponse {
+    private String name;
+    private String link;
+}

--- a/src/main/java/peer/backend/dto/board/team/PostLinkResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/PostLinkResponse.java
@@ -6,10 +6,17 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import peer.backend.entity.board.team.PostLink;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 @Getter
 @RequiredArgsConstructor
 public class PostLinkResponse {
+    @NotNull
+    @Pattern(regexp = "^[\\uAC00-\\uD7A3a-zA-Z0-9]+$")
     private String name;
+    @NotNull
+    @Pattern(regexp = "(https?:\\/\\/)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)")
     private String link;
 
     public PostLinkResponse(PostLink postLink){

--- a/src/main/java/peer/backend/dto/board/team/PostLinkResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/PostLinkResponse.java
@@ -1,13 +1,19 @@
 package peer.backend.dto.board.team;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import peer.backend.entity.board.team.PostLink;
 
 @Getter
 @RequiredArgsConstructor
-@Builder
 public class PostLinkResponse {
     private String name;
     private String link;
+
+    public PostLinkResponse(PostLink postLink){
+        this.name = postLink.getName();
+        this.link = postLink.getUrl();
+    }
 }

--- a/src/main/java/peer/backend/dto/board/team/ShowcaseCreateDto.java
+++ b/src/main/java/peer/backend/dto/board/team/ShowcaseCreateDto.java
@@ -1,0 +1,23 @@
+package peer.backend.dto.board.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class ShowcaseCreateDto {
+    @NotNull
+    private String image;
+    @NotNull
+    private Long teamId;
+    @NotNull
+    private String content;
+    private List<PostLinkResponse> links;
+}

--- a/src/main/java/peer/backend/dto/board/team/ShowcaseResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/ShowcaseResponse.java
@@ -1,17 +1,16 @@
 package peer.backend.dto.board.team;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import peer.backend.dto.profile.response.UserLinkResponse;
+import lombok.*;
 import peer.backend.dto.tag.TagResponse;
 import peer.backend.dto.user.UserShowcaseResponse;
+import peer.backend.entity.board.team.Post;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Builder
+@AllArgsConstructor
 @RequiredArgsConstructor
 public class ShowcaseResponse {
     private boolean author;
@@ -20,10 +19,10 @@ public class ShowcaseResponse {
     private boolean liked;
     private int likeCount;
     private String name;
-    private LocalDateTime start;
-    private LocalDateTime end;
+    private String start;
+    private String end;
     private List<TagResponse> skills;
     private List<UserShowcaseResponse> member;
-    private List<UserLinkResponse> links;
+    private List<PostLinkResponse> links;
     private String content;
 }

--- a/src/main/java/peer/backend/dto/board/team/ShowcaseResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/ShowcaseResponse.java
@@ -1,0 +1,29 @@
+package peer.backend.dto.board.team;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import peer.backend.dto.profile.response.UserLinkResponse;
+import peer.backend.dto.tag.TagResponse;
+import peer.backend.dto.user.UserShowcaseResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ShowcaseResponse {
+    private boolean author;
+    private String image;
+    private boolean favorite;
+    private boolean liked;
+    private int likeCount;
+    private String name;
+    private LocalDateTime start;
+    private LocalDateTime end;
+    private List<TagResponse> skills;
+    private List<UserShowcaseResponse> member;
+    private List<UserLinkResponse> links;
+    private String content;
+}

--- a/src/main/java/peer/backend/dto/board/team/ShowcaseWriteResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/ShowcaseWriteResponse.java
@@ -1,0 +1,19 @@
+package peer.backend.dto.board.team;
+
+import lombok.Getter;
+import peer.backend.dto.profile.response.UserLinkResponse;
+import peer.backend.dto.tag.TagResponse;
+import peer.backend.dto.user.UserShowcaseResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class ShowcaseWriteResponse {
+    private String title;
+    private List<TagResponse> skills;
+    private LocalDateTime start;
+    private LocalDateTime end;
+    private List<UserShowcaseResponse> memberList;
+    private List<UserLinkResponse>
+}

--- a/src/main/java/peer/backend/dto/board/team/ShowcaseWriteResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/ShowcaseWriteResponse.java
@@ -1,19 +1,39 @@
 package peer.backend.dto.board.team;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import peer.backend.dto.profile.response.UserLinkResponse;
 import peer.backend.dto.tag.TagResponse;
 import peer.backend.dto.user.UserShowcaseResponse;
+import peer.backend.entity.tag.Tag;
+import peer.backend.entity.team.Team;
+import peer.backend.entity.team.TeamUser;
+import peer.backend.entity.team.enums.TeamUserStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
 public class ShowcaseWriteResponse {
-    private String title;
+    private String name;
     private List<TagResponse> skills;
-    private LocalDateTime start;
-    private LocalDateTime end;
+    private String start;
+    private String end;
     private List<UserShowcaseResponse> memberList;
-    private List<UserLinkResponse>
+
+    public ShowcaseWriteResponse(Team team, List<Tag> tags, List<TeamUser> member){
+        this.name = team.getName();
+        this.skills = tags.stream().map(TagResponse::new).collect(Collectors.toList());
+        this.start = team.getCreatedAt().toString();
+        this.end = team.getEnd().toString();
+        this.memberList = member.stream()
+                .filter(teamUser -> teamUser.getStatus().equals(TeamUserStatus.APPROVED))
+                .map(UserShowcaseResponse::new).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/peer/backend/dto/user/UserShowcaseResponse.java
+++ b/src/main/java/peer/backend/dto/user/UserShowcaseResponse.java
@@ -2,6 +2,8 @@ package peer.backend.dto.user;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import peer.backend.entity.team.TeamUser;
+import peer.backend.entity.user.User;
 
 import java.util.List;
 
@@ -10,5 +12,12 @@ import java.util.List;
 public class UserShowcaseResponse {
     private String image;
     private String nickname;
-    private List<String> role;
+    private String role;
+
+    public UserShowcaseResponse(TeamUser teamUser){
+        User user = teamUser.getUser();
+        this.image = user.getImageUrl();
+        this.nickname = user.getNickname();
+        this.role = teamUser.getTeamUserJobs().get(0).getTeamJob().getName();
+    }
 }

--- a/src/main/java/peer/backend/dto/user/UserShowcaseResponse.java
+++ b/src/main/java/peer/backend/dto/user/UserShowcaseResponse.java
@@ -1,0 +1,14 @@
+package peer.backend.dto.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class UserShowcaseResponse {
+    private String image;
+    private String nickname;
+    private List<String> role;
+}

--- a/src/main/java/peer/backend/entity/board/team/Post.java
+++ b/src/main/java/peer/backend/entity/board/team/Post.java
@@ -46,6 +46,12 @@ public class Post extends BaseEntity{
     private String image;
     private int liked;
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<PostFile> files;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<PostLink> links;
+
     public void update(PostUpdateRequest request){
         this.title = request.getTitle();
         this.content = request.getContent();

--- a/src/main/java/peer/backend/entity/board/team/Post.java
+++ b/src/main/java/peer/backend/entity/board/team/Post.java
@@ -1,6 +1,7 @@
 package peer.backend.entity.board.team;
 
 import lombok.*;
+import peer.backend.dto.board.team.PostLinkResponse;
 import peer.backend.dto.board.team.PostUpdateRequest;
 import peer.backend.entity.BaseEntity;
 import peer.backend.entity.user.User;
@@ -71,5 +72,17 @@ public class Post extends BaseEntity{
         if (this.liked == 0)
             return ;
         this.liked -= 1;
+    }
+    public void addLinks(List<PostLinkResponse> linkList){
+        if (this.links == null)
+            this.links = new ArrayList<>();
+        if (linkList != null && !linkList.isEmpty())
+            linkList.forEach(link -> this.links.add(new PostLink(link)));
+    }
+
+    public void addFile(String url){
+        if (this.files == null)
+            this.files = new ArrayList<>();
+        files.add(new PostFile(url));
     }
 }

--- a/src/main/java/peer/backend/entity/board/team/PostFile.java
+++ b/src/main/java/peer/backend/entity/board/team/PostFile.java
@@ -1,0 +1,25 @@
+package peer.backend.entity.board.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostFile {
+    private Long id;
+    private String url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="post_id")
+    private Post post;
+}

--- a/src/main/java/peer/backend/entity/board/team/PostFile.java
+++ b/src/main/java/peer/backend/entity/board/team/PostFile.java
@@ -16,9 +16,14 @@ public class PostFile {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(nullable = false)
     private String url;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="post_id")
     private Post post;
+
+    public PostFile(String url){
+        this.url = url;
+    }
 }

--- a/src/main/java/peer/backend/entity/board/team/PostFile.java
+++ b/src/main/java/peer/backend/entity/board/team/PostFile.java
@@ -5,10 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -16,6 +13,8 @@ import javax.persistence.ManyToOne;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostFile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String url;
 

--- a/src/main/java/peer/backend/entity/board/team/PostLink.java
+++ b/src/main/java/peer/backend/entity/board/team/PostLink.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import peer.backend.dto.board.team.PostLinkResponse;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -12,19 +13,23 @@ import javax.validation.constraints.NotNull;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class PostLink {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
-    @NotNull
+    @Column(nullable = false)
     private String name;
-    @NotNull
+    @Column(nullable = false)
     private String url;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    public PostLink(PostLinkResponse request){
+        this.name = request.getName();
+        this.url = request.getLink();
+    }
 
 }

--- a/src/main/java/peer/backend/entity/board/team/PostLink.java
+++ b/src/main/java/peer/backend/entity/board/team/PostLink.java
@@ -1,0 +1,30 @@
+package peer.backend.entity.board.team;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostLink {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @NotNull
+    private String name;
+    @NotNull
+    private String url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+}

--- a/src/main/java/peer/backend/entity/team/Team.java
+++ b/src/main/java/peer/backend/entity/team/Team.java
@@ -90,6 +90,9 @@ public class Team extends BaseEntity {
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TeamJob> jobs;
 
+    @Column
+    private String showcaseContent;
+
     public Integer getMaxMember() {
         return getJobs().stream().mapToInt(TeamJob::getMax).sum();
     }

--- a/src/main/java/peer/backend/entity/team/Team.java
+++ b/src/main/java/peer/backend/entity/team/Team.java
@@ -10,6 +10,7 @@ import peer.backend.dto.team.TeamSettingInfoDto;
 import peer.backend.entity.BaseEntity;
 import peer.backend.entity.board.recruit.Recruit;
 import peer.backend.entity.board.recruit.enums.RecruitDueEnum;
+import peer.backend.entity.board.team.Board;
 import peer.backend.entity.team.enums.*;
 
 import javax.persistence.*;
@@ -89,6 +90,9 @@ public class Team extends BaseEntity {
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TeamJob> jobs;
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Board> boards;
 
     @Column
     private String showcaseContent;

--- a/src/main/java/peer/backend/repository/board/team/PostRepository.java
+++ b/src/main/java/peer/backend/repository/board/team/PostRepository.java
@@ -1,14 +1,18 @@
 package peer.backend.repository.board.team;
 
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import peer.backend.entity.board.team.Post;
 import peer.backend.entity.board.team.enums.BoardType;
+import peer.backend.entity.team.Team;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByBoardTeamIdAndBoardType(Long teamId, BoardType type);
     Page<Post> findAllByBoardTypeOrderByCreatedAtDesc(BoardType type, Pageable pageable);
 
     @Query(value = "SELECT * FROM post WHERE board_id = :boardId ORDER BY id DESC",

--- a/src/main/java/peer/backend/service/board/team/BoardService.java
+++ b/src/main/java/peer/backend/service/board/team/BoardService.java
@@ -64,7 +64,7 @@ public class BoardService {
         Board board = boardRepository.findById(request.getBoardId()).orElseThrow(
             () -> new NotFoundException("존재하지 않는 게시판입니다."));
         Team team = board.getTeam();
-        if (board.getType().equals(BoardType.NOTICE) && !teamService.isLeader(team.getId(), user)) {
+        if (!teamService.isLeader(team.getId(), user)) {
             throw new ForbiddenException("팀 리더가 아닙니다.");
         }
         Post post = Post.builder()

--- a/src/main/java/peer/backend/service/board/team/BoardService.java
+++ b/src/main/java/peer/backend/service/board/team/BoardService.java
@@ -64,7 +64,7 @@ public class BoardService {
         Board board = boardRepository.findById(request.getBoardId()).orElseThrow(
             () -> new NotFoundException("존재하지 않는 게시판입니다."));
         Team team = board.getTeam();
-        if (!teamService.isLeader(team.getId(), user)) {
+        if (board.getType().equals(BoardType.NOTICE) && !teamService.isLeader(team.getId(), user)) {
             throw new ForbiddenException("팀 리더가 아닙니다.");
         }
         Post post = Post.builder()

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import peer.backend.dto.board.team.ShowcaseListResponse;
+import peer.backend.dto.board.team.ShowcaseResponse;
 import peer.backend.entity.board.team.Post;
 import peer.backend.entity.board.team.PostLike;
 import peer.backend.entity.board.team.enums.BoardType;
@@ -19,6 +20,7 @@ import peer.backend.entity.board.team.enums.PostLikeType;
 import peer.backend.entity.composite.PostLikePK;
 import peer.backend.entity.team.Team;
 import peer.backend.entity.user.User;
+import peer.backend.exception.IllegalArgumentException;
 import peer.backend.exception.NotFoundException;
 import peer.backend.repository.board.team.PostLikeRepository;
 import peer.backend.repository.board.team.PostRepository;
@@ -112,5 +114,27 @@ public class ShowcaseService {
             showcase.increaseLike();
             return showcase.getLiked();
         }
+    }
+
+    public
+
+    @Transactional
+    public ShowcaseResponse getShowcase(Long showcaseId, Authentication auth){
+        Post showcase = postRepository.findById(showcaseId).orElseThrow(() -> new NotFoundException("존재하지 않는 쇼케이스입니다."));
+        if (!showcase.getBoard().getType().equals(BoardType.SHOWCASE))
+            throw new IllegalArgumentException("쇼케이스 게시물이 아닙니다.");
+        User user = User.authenticationToUser(auth)
+        Team team = showcase.getBoard().getTeam();
+        return ShowcaseResponse.builder()
+                .content(showcase.getContent())
+                .image(showcase.getImage())
+                .start(team.getCreatedAt())
+                .end(team.getEnd())
+                .likeCount(showcase.getLiked())
+                .liked(auth != null && postLikeRepository.findById(new PostLikePK(user.getId(), showcaseId, PostLikeType.LIKE)).isPresent())
+                .favorite(auth != null && postLikeRepository.findById(new PostLikePK(user.getId(), showcaseId, PostLikeType.FAVORITE)).isPresent())
+                .author(user.getId().equals(showcase.getUser().getId()))
+                .
+
     }
 }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
* showcase api 중 getList, getDetail, getTeamInfo, doLike, doFavorite, create 를 구현하였습니다.
* getList와 getDetail은 토큰 없이 조회가 가능해야 해서 security config에 해당 endpoint를 permit.ALL로 등록하였습니다.
* create와 getTeamInfo에서는 팀의 리더 여부를 검사합니다.
* create시에는 showcase타입의 board를 생성하고 post를 생성합니다.
* 나머지 댓글 관련 기능과 수정 삭제 기능은 따로 브랜치를 생성하여 작업합니다.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
postman