### PR TITLE
[Hotfix] #675 이미지 null로 보내지는 현상 수정

### DIFF
--- a/src/main/java/peer/backend/dto/board/team/ShowcaseUpdateDto.java
+++ b/src/main/java/peer/backend/dto/board/team/ShowcaseUpdateDto.java
@@ -12,6 +12,5 @@ public class ShowcaseUpdateDto {
     private String image;
     @NotNull
     private String content;
-    @NotNull
     private List<PostLinkResponse> links;
 }

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -62,7 +62,7 @@ public class ShowcaseService {
         Team team = post.getBoard().getTeam();
         return ShowcaseListResponse.builder()
             .id(post.getId())
-            .image(post.getImage())
+            .image(post.getFiles().get(0).getUrl())
             .name(post.getBoard().getTeam().getName())
             .description(post.getContent())
             .skill(

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -62,7 +62,7 @@ public class ShowcaseService {
         Team team = post.getBoard().getTeam();
         return ShowcaseListResponse.builder()
             .id(post.getId())
-            .image(post.getFiles().get(0).getUrl())
+            .image(post.getFiles().get(0).getUrl())     // showcase에서 대표이미지는 항상 첫번째인덱스에 있습니다.
             .name(post.getBoard().getTeam().getName())
             .description(post.getContent())
             .skill(

--- a/src/test/java/peer/backend/board/ShowcaseServiceTest.java
+++ b/src/test/java/peer/backend/board/ShowcaseServiceTest.java
@@ -25,9 +25,7 @@ import org.springframework.security.core.Authentication;
 import peer.backend.entity.board.recruit.Recruit;
 import peer.backend.entity.board.recruit.enums.RecruitDueEnum;
 import peer.backend.entity.board.recruit.enums.RecruitStatus;
-import peer.backend.entity.board.team.Board;
-import peer.backend.entity.board.team.Post;
-import peer.backend.entity.board.team.PostLike;
+import peer.backend.entity.board.team.*;
 import peer.backend.entity.board.team.enums.BoardType;
 import peer.backend.entity.team.Team;
 import peer.backend.entity.team.enums.TeamMemberStatus;
@@ -123,13 +121,16 @@ class ShowcaseServiceTest {
             .title("12345")
             .user(user)
             .board(board)
+            .files(new ArrayList<>())
+            .links(new ArrayList<>())
             .build();
         post.setCreatedAt(LocalDateTime.now());
         post.setUpdatedAt(LocalDateTime.now());
         PrincipalDetails details = new PrincipalDetails(user);
         auth = new UsernamePasswordAuthenticationToken(details, details.getPassword(),
             details.getAuthorities());
-
+        post.getFiles().add(PostFile.builder().id(1L).url("hello").build());
+        post.getLinks().add(PostLink.builder().id(1L).name("hello").url("hell").build());
         posts.add(post);
 
         mockPost = mock(Post.class);
@@ -137,7 +138,7 @@ class ShowcaseServiceTest {
     }
 
     @Test
-    @DisplayName("쇼케이스 리스트 가져오기 테스티")
+    @DisplayName("쇼케이스 리스트 가져오기 테스트")
     void getShowCaseListTest() {
         when(postRepository.findAllByBoardTypeOrderByCreatedAtDesc(any(), any()))
             .thenReturn(new PageImpl<>(posts, PageRequest.of(0, 2), 1L));


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- post 엔티티 내의 image 필드에서 postFiles의 첫번째 이미지를 불러오도록 변경
- showcase update Request의 linklist필드가 nullable하도록 수정

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
