### PR TITLE
[Hotfix] exclude private showcase from List & throw error when team statu…

### DIFF
--- a/src/main/java/peer/backend/repository/board/team/PostRepository.java
+++ b/src/main/java/peer/backend/repository/board/team/PostRepository.java
@@ -13,7 +13,7 @@ import peer.backend.entity.team.Team;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByBoardTeamIdAndBoardType(Long teamId, BoardType type);
-    Page<Post> findAllByBoardTypeOrderByCreatedAtDesc(BoardType type, Pageable pageable);
+    Page<Post> findAllByBoardTypeAndIsPublicOrderByCreatedAtDesc(BoardType type, boolean isPublic, Pageable pageable);
 
     @Query(value = "SELECT * FROM post WHERE board_id = :boardId ORDER BY id DESC",
             nativeQuery = true)

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -84,8 +84,10 @@ public class ShowcaseService {
     @Transactional
     public Page<ShowcaseListResponse> getShowCaseList(int page, int pageSize, Authentication auth) {
         Pageable pageable = PageRequest.of(page, pageSize);
-        Page<Post> posts = postRepository.findAllByBoardTypeOrderByCreatedAtDesc(BoardType.SHOWCASE,
-            pageable);
+        Page<Post> posts = postRepository.findAllByBoardTypeAndIsPublicOrderByCreatedAtDesc(
+                BoardType.SHOWCASE,
+                true,
+                pageable);
 
         return posts.map(post -> convertToDto(post, auth));
     }
@@ -166,6 +168,8 @@ public class ShowcaseService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 팀입니다."));
         if (!teamService.isLeader(teamId, user))
             throw new ForbiddenException("리더가 아닙니다.");
+        if (!team.getStatus().equals(TeamStatus.COMPLETE))
+            throw new ConflictException("팀이 종료되지 않았습니다.");
         return new ShowcaseWriteResponse(
                 team,
                 tagService.recruitTagListToTagList(team.getRecruit().getRecruitTags()),

--- a/src/test/java/peer/backend/board/ShowcaseServiceTest.java
+++ b/src/test/java/peer/backend/board/ShowcaseServiceTest.java
@@ -1,8 +1,7 @@
 package peer.backend.board;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -143,7 +142,7 @@ class ShowcaseServiceTest {
     @Test
     @DisplayName("쇼케이스 리스트 가져오기 테스트")
     void getShowCaseListTest() {
-        when(postRepository.findAllByBoardTypeOrderByCreatedAtDesc(any(), any()))
+        when(postRepository.findAllByBoardTypeAndIsPublicOrderByCreatedAtDesc(any(), anyBoolean(), any()))
             .thenReturn(new PageImpl<>(posts, PageRequest.of(0, 2), 1L));
 
         assertThat(showcaseService.getShowCaseList(0, 1, auth).getTotalElements()).isEqualTo(1);


### PR DESCRIPTION
…s is not completed

## 변경 사항
<!-- 변경 사항을 입력합니다. -->
팀이 완료되지 않았을 때 쇼케이스 작성 시도시 에러 반환(409)
비공개 쇼케이스를 리스트에서 제외


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
