### PR TITLE
736 hotfix board

### DIFF
--- a/src/main/java/peer/backend/controller/team/TeamPageController.java
+++ b/src/main/java/peer/backend/controller/team/TeamPageController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import peer.backend.dto.board.team.BoardPostRes;
 import peer.backend.dto.board.team.PostCreateRequest;
+import peer.backend.dto.board.team.PostNoticeReq;
 import peer.backend.dto.team.PostDetail;
 import peer.backend.dto.team.PostRes;
 import peer.backend.dto.team.SimpleBoardRes;
@@ -71,9 +72,9 @@ public class TeamPageController {
 
     @ApiOperation(value = "TEAM-PAGE-NOTICE", notes = "공지사항 게시판에 공지사항 글 게시.")
     @PostMapping("/notice/create")
-    public ResponseEntity<BoardPostRes> createNoticePost(@RequestBody PostCreateRequest postCreateRequest,
+    public ResponseEntity<BoardPostRes> createNoticePost(@RequestBody PostNoticeReq postNoticeReq,
                                                          Authentication auth) {
-        BoardPostRes res = BoardPostRes.from(teamPageService.createNoticePost(postCreateRequest, auth));
+        BoardPostRes res = BoardPostRes.from(teamPageService.createNoticePost(postNoticeReq, auth));
         return ResponseEntity.ok(res);
     }
 

--- a/src/main/java/peer/backend/dto/board/team/PostNoticeReq.java
+++ b/src/main/java/peer/backend/dto/board/team/PostNoticeReq.java
@@ -1,0 +1,16 @@
+package peer.backend.dto.board.team;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostNoticeReq {
+    private Long teamId;
+    private String content;
+    private String title;
+    private String image;
+}

--- a/src/main/java/peer/backend/repository/board/team/BoardRepository.java
+++ b/src/main/java/peer/backend/repository/board/team/BoardRepository.java
@@ -14,9 +14,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Optional<Board> findByTeamAndName(Team team, String name);
 
-    @Query(value = "SELECT * FROM board WHERE team_id = :teamId ORDER BY id DESC",
-            nativeQuery = true)
-    List<Board> findByTeamId(Long teamId);
+
+    List<Board> findBoardsByTeamIdAndType(Long teamId, BoardType type);
 
     Optional<Board> findByTeamIdAndType(Long teamId, BoardType type);
 }

--- a/src/main/java/peer/backend/service/board/team/BoardService.java
+++ b/src/main/java/peer/backend/service/board/team/BoardService.java
@@ -96,7 +96,7 @@ public class BoardService {
     @Transactional
     public List<SimpleBoardRes> getSimpleBoards(Long teamId, Authentication auth) {
         User user = User.authenticationToUser(auth);
-        List<SimpleBoardRes> boards = boardRepository.findByTeamId(teamId)
+        List<SimpleBoardRes> boards = boardRepository.findBoardsByTeamIdAndType(teamId, BoardType.NORMAL)
                 .stream()
                 .map(board -> new SimpleBoardRes(board.getId(), board.getName()))
                 .collect(Collectors.toList());

--- a/src/main/java/peer/backend/service/teampage/TeamPageService.java
+++ b/src/main/java/peer/backend/service/teampage/TeamPageService.java
@@ -7,9 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import peer.backend.dto.board.team.PostCreateRequest;
+import peer.backend.dto.board.team.PostNoticeReq;
 import peer.backend.dto.team.PostRes;
 import peer.backend.entity.board.team.Board;
 import peer.backend.entity.board.team.Post;
+import peer.backend.entity.board.team.enums.BoardType;
 import peer.backend.entity.team.Team;
 import peer.backend.entity.user.User;
 import peer.backend.exception.ForbiddenException;
@@ -63,13 +65,11 @@ public class TeamPageService {
     }
 
     @Transactional
-    public Post createNoticePost(PostCreateRequest request, Authentication auth) {
+    public Post createNoticePost(PostNoticeReq request, Authentication auth) {
         User user = User.authenticationToUser(auth);
-        Board board = boardRepository.findById(request.getBoardId()).orElseThrow(
-                () -> new NotFoundException("존재하지 않는 게시판입니다."));
-        if (!board.getType().getType().equals("NOTICE")) {
-            throw new ForbiddenException("공지사항 게시판이 아닙니다.");
-        }
+
+        Board board = boardRepository.findByTeamIdAndType(request.getTeamId(), BoardType.NOTICE).orElseThrow(
+                () -> new NotFoundException("게시판이 존재하지 않습니다."));
         Team team = board.getTeam();
         if (!teamUserRepository.existsAndMemberByUserIdAndTeamId(user.getId(), team.getId())) {
             throw new ForbiddenException("팀 리더가 아닙니다.");


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
게시판 간편 목록에서 공지사항 게시판까지 전달되는 것을
일반 게시판만 불러오도록 수정.

프론트에서 게시판 아이디를 가지고 있지 않기 때문에,
보드 아이디에서 팀 아이디로 변경.
팀 아이디를 통해 공지사항 게시판을 찾고 글 작성을 하도록 코드 수정.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
