### PR TITLE
[Hotfix] get showcase comments without token

### DIFF
--- a/src/main/java/peer/backend/config/SecurityConfig.java
+++ b/src/main/java/peer/backend/config/SecurityConfig.java
@@ -84,7 +84,7 @@ public class SecurityConfig {
             .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/hitch/*", "/api/v1/hitch")
             .permitAll()
-            .antMatchers(HttpMethod.GET, "/api/v1/showcase/*", "/api/v1/showcase")
+            .antMatchers(HttpMethod.GET, "/api/v1/showcase/*", "/api/v1/showcase", "/api/v1/showcase/comment/*")
             .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/profile/other")
             .permitAll()

--- a/src/main/java/peer/backend/controller/board/BoardController.java
+++ b/src/main/java/peer/backend/controller/board/BoardController.java
@@ -2,10 +2,15 @@ package peer.backend.controller.board;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import peer.backend.dto.board.team.*;
+import peer.backend.entity.board.team.enums.BoardType;
+import peer.backend.entity.user.User;
 import peer.backend.exception.OutOfRangeException;
 import peer.backend.service.board.team.BoardService;
 
@@ -58,7 +63,11 @@ public class BoardController {
 
     @PostMapping("/post/comment")
     public void createComment(@RequestBody @Valid PostCommentRequest request, Authentication auth) {
-        boardService.createComment(request, auth);
+        boardService.createComment(
+                request.getPostId(),
+                request.getContent(),
+                User.authenticationToUser(auth),
+                BoardType.NORMAL);
     }
 
     @PutMapping("/post/comment/{commentId}")
@@ -76,7 +85,8 @@ public class BoardController {
             Authentication auth) {
         if (page < 1 || pageSize < 0)
             throw new OutOfRangeException("페이지는 1부터 시작합니다.");
-        return boardService.getComments(postId, page - 1, pageSize, auth);
+        Pageable pageable = PageRequest.of(page - 1, pageSize, Sort.by("createdAt").descending());
+        return boardService.getComments(postId, pageable, User.authenticationToUser(auth), BoardType.NORMAL);
     }
 
     @DeleteMapping("/post/comment/{commentId}")

--- a/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
@@ -28,6 +28,6 @@ public class PostCommentListResponse {
         this.authorNickname = (author == null) ? "탈퇴한 유저" : author.getNickname();
         this.content = comment.getContent();
         this.createAt = comment.getCreatedAt().toString();
-        this.isAuthor = user.equals(author);
+        this.isAuthor = user != null && user.equals(author);
     }
 }

--- a/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
@@ -21,13 +21,13 @@ public class PostCommentListResponse {
     @JsonProperty("isAuthor")
     private boolean isAuthor;
 
-    public PostCommentListResponse(PostComment comment){
-        User user = comment.getUser();
+    public PostCommentListResponse(PostComment comment, User user){
+        User author = comment.getUser();
         this.commentId = comment.getId();
-        this.authorImage = (user == null) ? null : user.getImageUrl();
-        this.authorNickname = (user == null) ? "탈퇴한 유저" : user.getNickname();
+        this.authorImage = (author == null) ? null : author.getImageUrl();
+        this.authorNickname = (author == null) ? "탈퇴한 유저" : author.getNickname();
         this.content = comment.getContent();
         this.createAt = comment.getCreatedAt().toString();
-        this.isAuthor = comment.getUser().equals(user);
+        this.isAuthor = user.equals(author);
     }
 }

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -266,7 +266,6 @@ public class ShowcaseService {
         if (!teamService.isLeader(post.getBoard().getTeam().getId(), user))
             throw new ForbiddenException("리더가 아닙니다.");
         post.changeIsPublic();
-
         return post.isPublic();
     }
 }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
* 게시판 댓글 작성, 조회시 게시판 종류에 따라 유효성 검사를 달리할 수 있도록 수정
* 쇼케이스의 댓글 조회의 경우 토큰이 없어도 조회할 수 있도록 수정


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
