### PR TITLE
[Hotfix] showcase comment without token

### DIFF
--- a/src/main/java/peer/backend/config/SecurityConfig.java
+++ b/src/main/java/peer/backend/config/SecurityConfig.java
@@ -84,7 +84,7 @@ public class SecurityConfig {
             .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/hitch/*", "/api/v1/hitch")
             .permitAll()
-            .antMatchers(HttpMethod.GET, "/api/v1/showcase/*", "/api/v1/showcase")
+            .antMatchers(HttpMethod.GET, "/api/v1/showcase/*", "/api/v1/showcase", "/api/v1/showcase/comment/*")
             .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/profile/other")
             .permitAll()

--- a/src/main/java/peer/backend/controller/board/BoardController.java
+++ b/src/main/java/peer/backend/controller/board/BoardController.java
@@ -20,6 +20,7 @@ import peer.backend.dto.board.team.PostCommentRequest;
 import peer.backend.dto.board.team.PostCommentUpdateRequest;
 import peer.backend.dto.board.team.PostCreateRequest;
 import peer.backend.dto.board.team.PostUpdateRequest;
+import peer.backend.entity.board.team.enums.BoardType;
 import peer.backend.entity.user.User;
 import peer.backend.service.board.team.BoardService;
 
@@ -32,12 +33,12 @@ public class BoardController {
 
     @PostMapping("/board/create")
     public void createBoard(@RequestBody BoardCreateRequest request, Authentication auth) {
-        boardService.createBoard(request, auth);
+        boardService.createBoard(request, User.authenticationToUser(auth));
     }
 
     @PostMapping("/post/create")
     public void createPost(@RequestBody PostCreateRequest request, Authentication auth) {
-        boardService.createPost(request, auth);
+        boardService.createPost(request, User.authenticationToUser(auth));
     }
 
     @GetMapping("/board/list/{teamId}")
@@ -70,7 +71,11 @@ public class BoardController {
 
     @PostMapping("/post/comment")
     public void createComment(@RequestBody @Valid PostCommentRequest request, Authentication auth) {
-        boardService.createComment(request, auth);
+        boardService.createComment(
+                request.getPostId(),
+                request.getContent(),
+                User.authenticationToUser(auth),
+                BoardType.NORMAL);
     }
 
     @PutMapping("/post/comment/{commentId}")
@@ -82,8 +87,10 @@ public class BoardController {
 
     @GetMapping("/post/comment/{postId}")
     public List<PostCommentListResponse> getComments(@PathVariable Long postId, Authentication auth) {
-        User user = User.authenticationToUser(auth);
-        return boardService.getComments(postId, user.getId());
+        return boardService.getComments(
+                postId,
+                User.authenticationToUser(auth),
+                BoardType.NORMAL);
     }
 
     @DeleteMapping("/post/comment/{commentId}")

--- a/src/main/java/peer/backend/controller/board/BoardController.java
+++ b/src/main/java/peer/backend/controller/board/BoardController.java
@@ -82,7 +82,7 @@ public class BoardController {
     public void updateComment(@PathVariable Long commentId,
                               @RequestBody @Valid PostCommentUpdateRequest request,
                               Authentication auth) {
-        boardService.updateComment(commentId, request, auth);
+        boardService.updateComment(commentId, request, User.authenticationToUser(auth));
     }
 
     @GetMapping("/post/comment/{postId}")
@@ -95,6 +95,6 @@ public class BoardController {
 
     @DeleteMapping("/post/comment/{commentId}")
     public ResponseEntity<Object> deleteComment(@PathVariable Long commentId, Authentication auth) {
-        return boardService.deleteComment(commentId, auth);
+        return boardService.deleteComment(commentId, User.authenticationToUser(auth));
     }
 }

--- a/src/main/java/peer/backend/controller/board/ShowcaseController.java
+++ b/src/main/java/peer/backend/controller/board/ShowcaseController.java
@@ -7,11 +7,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import peer.backend.dto.board.team.*;
+import peer.backend.entity.board.team.enums.BoardType;
 import peer.backend.entity.user.User;
+import peer.backend.service.board.team.BoardService;
 import peer.backend.service.board.team.ShowcaseService;
 import peer.backend.service.profile.UserPortfolioService;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class ShowcaseController {
 
     private final ShowcaseService showcaseService;
     private final UserPortfolioService userPortfolioService;
+    private final BoardService boardService;
 
     @GetMapping("")
     public Page<ShowcaseListResponse> getShowcaseList(@RequestParam int page, @RequestParam int pageSize, Authentication auth){
@@ -73,5 +77,24 @@ public class ShowcaseController {
     @PostMapping("/public/{showcaseId}")
     public boolean changeShowcasePublic(@PathVariable Long showcaseId, Authentication auth){
         return showcaseService.changeShowcasePublic(showcaseId, User.authenticationToUser(auth));
+    }
+
+    @GetMapping("/comment/{showcaseId}")
+    public List<PostCommentListResponse> getShowcaseComment(@PathVariable Long showcaseId, Authentication auth){
+        try {
+            User user = User.authenticationToUser(auth);
+            return boardService.getComments(showcaseId, user, BoardType.SHOWCASE);
+        } catch (Exception e) {
+            return boardService.getComments(showcaseId, null, BoardType.SHOWCASE);
+        }
+    }
+
+    @PostMapping("/comment")
+    public void createShowcaseComment(@RequestBody PostCommentRequest request, Authentication auth){
+        boardService.createComment(
+                request.getPostId(),
+                request.getContent(),
+                User.authenticationToUser(auth),
+                BoardType.SHOWCASE);
     }
 }

--- a/src/main/java/peer/backend/controller/board/ShowcaseController.java
+++ b/src/main/java/peer/backend/controller/board/ShowcaseController.java
@@ -80,7 +80,7 @@ public class ShowcaseController {
     }
 
     @GetMapping("/comment/{showcaseId}")
-    public List<PostCommentListResponse> getShowcaseComment(@PathVariable Long showcaseId, Authentication auth){
+    public List<PostCommentListResponse> getShowcaseComments(@PathVariable Long showcaseId, Authentication auth){
         try {
             User user = User.authenticationToUser(auth);
             return boardService.getComments(showcaseId, user, BoardType.SHOWCASE);
@@ -96,5 +96,15 @@ public class ShowcaseController {
                 request.getContent(),
                 User.authenticationToUser(auth),
                 BoardType.SHOWCASE);
+    }
+
+    @DeleteMapping("/comment/{commentId}")
+    public void deleteShowcaseComment(@PathVariable Long commentId, Authentication auth){
+        boardService.deleteComment(commentId, User.authenticationToUser(auth));
+    }
+
+    @PutMapping("/comment/{commentId}")
+    public void updateShowcaseComment(@PathVariable Long commentId, @RequestBody PostCommentUpdateRequest request, Authentication auth){
+        boardService.updateComment(commentId, request, User.authenticationToUser(auth));
     }
 }

--- a/src/main/java/peer/backend/controller/team/TeamPageController.java
+++ b/src/main/java/peer/backend/controller/team/TeamPageController.java
@@ -59,7 +59,7 @@ public class TeamPageController {
     @GetMapping("/simple/{teamId}")
     public ResponseEntity<List<SimpleBoardRes>> getSimpleBoardList(@PathVariable("teamId") Long teamId,
                                                                    Authentication auth) {
-        List<SimpleBoardRes> boards = boardService.getSimpleBoards(teamId, auth);
+        List<SimpleBoardRes> boards = boardService.getSimpleBoards(teamId, User.authenticationToUser(auth));
         return ResponseEntity.ok(boards);
     }
 

--- a/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import peer.backend.entity.board.team.PostComment;
 import peer.backend.entity.user.User;
 
+import java.util.Objects;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -21,13 +23,13 @@ public class PostCommentListResponse {
     @JsonProperty("isAuthor")
     private boolean isAuthor;
 
-    public PostCommentListResponse(PostComment comment){
-        User user = comment.getUser();
+    public PostCommentListResponse(PostComment comment, User user){
+        User author = comment.getUser();
         this.commentId = comment.getId();
-        this.authorImage = (user == null) ? null : user.getImageUrl();
-        this.authorNickname = (user == null) ? "탈퇴한 유저" : user.getNickname();
+        this.authorImage = (author == null) ? null : author.getImageUrl();
+        this.authorNickname = (author == null) ? "탈퇴한 유저" : author.getNickname();
         this.content = comment.getContent();
         this.createAt = comment.getCreatedAt().toString();
-        this.isAuthor = comment.getUser().equals(user);
+        this.isAuthor = Objects.equals(author, user);
     }
 }

--- a/src/main/java/peer/backend/service/board/team/BoardService.java
+++ b/src/main/java/peer/backend/service/board/team/BoardService.java
@@ -176,8 +176,7 @@ public class BoardService {
     }
 
     @Transactional
-    public void updateComment(Long commentId, PostCommentUpdateRequest request, Authentication auth) {
-        User user = User.authenticationToUser(auth);
+    public void updateComment(Long commentId, PostCommentUpdateRequest request, User user) {
         PostComment comment = postCommentRepository.findById(commentId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
         if (!user.equals(comment.getUser())) {
@@ -210,10 +209,10 @@ public class BoardService {
     }
 
     @Transactional
-    public ResponseEntity<Object> deleteComment(Long commentId, Authentication auth) {
+    public ResponseEntity<Object> deleteComment(Long commentId, User user) {
         PostComment comment = postCommentRepository.findById(commentId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
-        if (!comment.getUser().equals(User.authenticationToUser(auth))) {
+        if (!comment.getUser().equals(user)) {
             throw new ForbiddenException("작성자가 아닙니다");
         }
         postCommentRepository.delete(comment);

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -266,7 +266,6 @@ public class ShowcaseService {
         if (!teamService.isLeader(post.getBoard().getTeam().getId(), user))
             throw new ForbiddenException("리더가 아닙니다.");
         post.changeIsPublic();
-
         return post.isPublic();
     }
 }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
* 게시판 댓글 조회, 작성 권한이 달라 showcaseController에 comment crud 컨트롤러 추가
* 각 서비스 로직에 boardtype검사로 게시판 종류에 따른 권한 검사 추가
*  showcase의 댓글을 조회할 수 있도록 security config 필터체인에 추가
* controller의존성을 줄이기 위해 Authentication 파라미터를 User로 변경


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
