### PR TITLE
FIX: redis connection settings

### DIFF
--- a/src/main/java/peer/backend/config/RedisRepositoryConfig.java
+++ b/src/main/java/peer/backend/config/RedisRepositoryConfig.java
@@ -3,16 +3,17 @@ package peer.backend.config;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.*;
 import peer.backend.dto.dnd.TeamMember;
-import peer.backend.entity.team.TeamUser;
 import peer.backend.entity.user.SocialLogin;
 
 import java.util.List;
@@ -21,13 +22,23 @@ import java.util.List;
 @Configuration
 @EnableRedisRepositories
 public class RedisRepositoryConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
 
-    private final RedisProperties redisProperties;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
 
     // lettuce
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+//        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setDatabase(0);
+        config.setPassword(password);
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
1. redis config 가 담긴yml 파일의 위치를 spring,data.~ 으로 이동 
2. redis config 가 그냥 Redis config factory  객체를 바로 직결하는 것에서, 객체를 만들고 설정을 불러와 connection 하는 구조로 변경 


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
