### PR TITLE
[Hotfix] update recruit

### DIFF
--- a/src/main/java/peer/backend/dto/board/recruit/RecruitUpdateRequestDTO.java
+++ b/src/main/java/peer/backend/dto/board/recruit/RecruitUpdateRequestDTO.java
@@ -37,7 +37,7 @@ public class RecruitUpdateRequestDTO {
     private List<TeamJobDto> roleList;
     private List<RecruitInterviewDto> interviewList;
     private String image;
-    private int max;
+    private Integer max;
 
     public String getRegion1() {
         if ((this.region == null && this.place.equals("OFFLINE")) ||

--- a/src/main/java/peer/backend/dto/board/recruit/RecruitUpdateRequestDTO.java
+++ b/src/main/java/peer/backend/dto/board/recruit/RecruitUpdateRequestDTO.java
@@ -28,7 +28,6 @@ public class RecruitUpdateRequestDTO {
     @NotNull
     private String due;
     @NotNull
-    @Lob
     private String content;
     private List<String> region;
     private String link;
@@ -38,6 +37,7 @@ public class RecruitUpdateRequestDTO {
     private List<TeamJobDto> roleList;
     private List<RecruitInterviewDto> interviewList;
     private String image;
+    private int max;
 
     public String getRegion1() {
         if ((this.region == null && this.place.equals("OFFLINE")) ||

--- a/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -78,6 +78,7 @@ public class Recruit extends BaseEntity {
         this.status = RecruitStatus.from(request.getStatus());
         this.link = request.getLink();
         this.recruitTags.clear();
+        if (request.getTagList() != null && !request.getTagList().isEmpty())
         this.recruitTags = request.getTagList().stream()
                 .map(e -> (new RecruitTag(this.id, e)))
                 .collect(

--- a/src/main/java/peer/backend/entity/team/Team.java
+++ b/src/main/java/peer/backend/entity/team/Team.java
@@ -58,7 +58,7 @@ public class Team extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     @Size(min = 2, max = 30)
     private String name;
 
@@ -152,6 +152,8 @@ public class Team extends BaseEntity {
         if (request.getRoleList() != null && !request.getInterviewList().isEmpty()) {
             request.getRoleList().forEach(this::addRole);
         }
+        if (request.getMax() != null)
+            this.maxMember = request.getMax();
     }
 
     public void addRole(TeamJobDto role) {

--- a/src/main/java/peer/backend/entity/team/Team.java
+++ b/src/main/java/peer/backend/entity/team/Team.java
@@ -143,7 +143,7 @@ public class Team extends BaseEntity {
     public void update(RecruitUpdateRequestDTO request) {
         this.name = request.getName();
         this.dueTo = RecruitDueEnum.from(request.getDue());
-        if (!request.getRegion().isEmpty()) {
+        if (request.getRegion() != null && !request.getRegion().isEmpty()) {
             this.region1 = request.getRegion1();
             this.region2 = request.getRegion2();
         }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
* team의 name에 unique 속성때문에 update 실패 -> 정책상 unique 속성 삭제로 결정
* 팀 엔티티에서 name에 unique 속성 삭제 후 db에서 unique로 인한 키 설정 수동 삭제
+ 잃어버린 null 에러 처리

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
