### PR TITLE
[Hotfix] toast editor foldername and content process

### DIFF
--- a/src/main/java/peer/backend/controller/board/RecruitController.java
+++ b/src/main/java/peer/backend/controller/board/RecruitController.java
@@ -1,7 +1,7 @@
 package peer.backend.controller.board;
 
 import io.swagger.annotations.ApiOperation;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -13,6 +13,8 @@ import peer.backend.dto.board.recruit.*;
 import peer.backend.entity.board.recruit.Recruit;
 import peer.backend.entity.board.recruit.enums.RecruitFavoriteEnum;
 import peer.backend.entity.user.User;
+import peer.backend.exception.NotFoundException;
+import peer.backend.repository.board.recruit.RecruitRepository;
 import peer.backend.service.board.recruit.RecruitService;
 
 import javax.validation.Valid;
@@ -114,5 +116,4 @@ public class RecruitController {
             return recruitService.getFavorite(recruit_id, null);
         }
     }
-
 }

--- a/src/main/java/peer/backend/controller/board/ShowcaseController.java
+++ b/src/main/java/peer/backend/controller/board/ShowcaseController.java
@@ -90,7 +90,7 @@ public class ShowcaseController {
     }
 
     @PostMapping("/comment")
-    public void createShowcaseComment(@RequestBody PostCommentRequest request, Authentication auth){
+    public void createShowcaseComment(@RequestBody @Valid PostCommentRequest request, Authentication auth){
         boardService.createComment(
                 request.getPostId(),
                 request.getContent(),
@@ -104,7 +104,7 @@ public class ShowcaseController {
     }
 
     @PutMapping("/comment/{commentId}")
-    public void updateShowcaseComment(@PathVariable Long commentId, @RequestBody PostCommentUpdateRequest request, Authentication auth){
+    public void updateShowcaseComment(@PathVariable Long commentId, @RequestBody @Valid PostCommentUpdateRequest request, Authentication auth){
         boardService.updateComment(commentId, request, User.authenticationToUser(auth));
     }
 }

--- a/src/main/java/peer/backend/controller/object/ObjectController.java
+++ b/src/main/java/peer/backend/controller/object/ObjectController.java
@@ -1,8 +1,10 @@
 package peer.backend.controller.object;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import peer.backend.entity.user.User;
 import peer.backend.service.file.ObjectService;
 
 import java.io.IOException;
@@ -15,7 +17,7 @@ public class ObjectController {
     private final ObjectService objectService;
 
     @PostMapping("/editor/image")
-    public String uploadImage(@RequestParam("image")MultipartFile image) throws IOException {
-        return objectService.uploadImage(image);
+    public String uploadImage(@RequestParam("image")MultipartFile image, Authentication auth) throws IOException {
+        return objectService.uploadImage(image, "editor/" + User.authenticationToUser(auth).getId());
     }
 }

--- a/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -55,6 +55,7 @@ public class Recruit extends BaseEntity {
     private String title;
 
     @Column(nullable = false)
+    @Lob
     private String content;
     @Column
     private String link;
@@ -71,7 +72,7 @@ public class Recruit extends BaseEntity {
     @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<UserPortfolio> userPortfoliosHistories;
 
-    public void update(RecruitUpdateRequestDTO request) {
+    public void update(RecruitUpdateRequestDTO request, List<String> urls) {
         this.getTeam().update(request);
         this.title = request.getTitle();
         this.content = request.getContent();
@@ -88,6 +89,10 @@ public class Recruit extends BaseEntity {
             for (RecruitInterviewDto interview : request.getInterviewList()) {
                 this.addInterview(interview);
             }
+        }
+        this.files.clear();
+        if (urls != null && !urls.isEmpty()) {
+            urls.forEach(this::addFile);
         }
     }
 
@@ -107,9 +112,18 @@ public class Recruit extends BaseEntity {
         this.hit = hit;
     }
 
-    public void addFiles(String url) {
+    public void addFiles(List<String> urls){
+        urls.forEach(this::addFile);
+    }
+
+    public void addFile(String url) {
         if (this.files == null)
             this.files = new ArrayList<>();
-        this.files.add(RecruitFile.builder().recruit(this).url(url).build());
+        this.files.add(
+                RecruitFile.builder()
+                        .recruit(this)
+                        .url(url)
+                        .build()
+        );
     }
 }

--- a/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -106,4 +106,10 @@ public class Recruit extends BaseEntity {
     public void setHit(Long hit) {
         this.hit = hit;
     }
+
+    public void addFiles(String url) {
+        if (this.files == null)
+            this.files = new ArrayList<>();
+        this.files.add(RecruitFile.builder().recruit(this).url(url).build());
+    }
 }

--- a/src/main/java/peer/backend/entity/board/recruit/RecruitFile.java
+++ b/src/main/java/peer/backend/entity/board/recruit/RecruitFile.java
@@ -1,15 +1,12 @@
 package peer.backend.entity.board.recruit;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
-@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "recruit_file")

--- a/src/main/java/peer/backend/entity/board/team/Post.java
+++ b/src/main/java/peer/backend/entity/board/team/Post.java
@@ -67,17 +67,22 @@ public class Post extends BaseEntity{
         this.isPublic = !this.isPublic;
     }
 
-    public void update(PostUpdateRequest request){
+    public void update(PostUpdateRequest request, List<String>urls){
         this.title = request.getTitle();
         this.content = request.getContent();
+        this.files.clear();
+        this.addFiles(urls);
     }
 
-    public void update(ShowcaseUpdateDto request, String url){
+    public void update(ShowcaseUpdateDto request, String url, List<String> urls){
         this.content = request.getContent();
         this.links.clear();
         this.clearAndAddLink(request.getLinks());
         if (url != null)
-            this.clearAndAddFile(url);
+            this.image = url;
+        this.files.clear();
+        if (urls != null && !urls.isEmpty())
+            addFiles(urls);
     }
 
     public void setImage(String url){
@@ -101,6 +106,10 @@ public class Post extends BaseEntity{
             this.links = new ArrayList<>();
         if (linkList != null && !linkList.isEmpty())
             linkList.forEach(link -> this.links.add(new PostLink(link, this)));
+    }
+
+    public void addFiles(List<String> urls){
+        urls.forEach(this::addFile);
     }
 
     public void addFile(String url){

--- a/src/main/java/peer/backend/entity/board/team/PostComment.java
+++ b/src/main/java/peer/backend/entity/board/team/PostComment.java
@@ -27,7 +27,7 @@ public class PostComment extends BaseEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @Lob
+    @Column(length = 300)
     private String content;
 
     public void update(String comment){

--- a/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -352,13 +352,6 @@ public class RecruitService {
     @RecruitWritingTracking
     public Recruit createRecruit(RecruitCreateRequest request, Authentication auth) {
         User user = User.authenticationToUser(auth);
-        //동일한 팀 이름 검사
-        teamRepository.findByName(request.getName()).ifPresent(
-            team1 -> {
-                throw new IllegalArgumentException("이미 존재하는 팀 이름입니다.");
-            }
-        );
-
         //팀 생성
         Team team = this.teamService.createTeam(user, request);
 

--- a/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -384,6 +384,8 @@ public class RecruitService {
         Recruit recruit = recruitRepository.findById(recruit_id).orElseThrow(
             () -> new NotFoundException("존재하지 않는 모집게시글입니다."));
         objectService.deleteObject(recruit.getThumbnailUrl());
+        if (recruit.getFiles() != null && !recruit.getFiles().isEmpty())
+            recruit.getFiles().forEach(file -> objectService.deleteObject(file.getUrl()));
         recruitRepository.delete(recruit);
     }
 

--- a/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -345,6 +345,7 @@ public class RecruitService {
             .hit(0L)
             .build();
         addInterviewsToRecruit(recruit, request.getInterviewList());
+        recruit.b.add
         return recruit;
     }
 

--- a/src/main/java/peer/backend/service/board/team/BoardService.java
+++ b/src/main/java/peer/backend/service/board/team/BoardService.java
@@ -164,6 +164,9 @@ public class BoardService {
         if (post.getImage() != null) {
             objectService.deleteObject(post.getImage());
         }
+        if (post.getFiles() != null && !post.getFiles().isEmpty()) {
+            post.getFiles().forEach(postFile -> objectService.deleteObject(postFile.getUrl()));
+        }
         postRepository.delete(post);
     }
 

--- a/src/main/java/peer/backend/service/board/team/BoardService.java
+++ b/src/main/java/peer/backend/service/board/team/BoardService.java
@@ -83,6 +83,7 @@ public class BoardService {
                         request.getImage(), "board/" + board.getId(), "image"))
                 .build();
         postRepository.save(post);
+        post.addFiles(objectService.extractContentImage(request.getContent()));
     }
 
     @Transactional
@@ -127,7 +128,7 @@ public class BoardService {
                 user)) {
             throw new ForbiddenException("게시글을 수정할 권한이 업습니다.");
         }
-        post.update(request);
+        post.update(request, objectService.extractContentImage(request.getContent()));
         if (request.getImage() != null) {
             objectService.deleteObject(post.getImage());
             objectService.uploadObject(request.getImage(), "board/" + post.getBoard().getId(),

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -239,8 +239,12 @@ public class ShowcaseService {
         Team team = post.getBoard().getTeam();
         if (!teamService.isLeader(team.getId(), user))
             throw new ForbiddenException("리더가 아닙니다.");
-        objectService.deleteObject(post.getFiles().get(0).getUrl());
+        if (post.getImage() != null)
+            objectService.deleteObject(post.getImage());
+        if (post.getFiles() != null && !post.getFiles().isEmpty())
+            post.getFiles().forEach(file -> objectService.deleteObject(file.getUrl()));
         boardRepository.delete(post.getBoard());
+        postRepository.delete(post);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/peer/backend/service/file/ObjectService.java
+++ b/src/main/java/peer/backend/service/file/ObjectService.java
@@ -97,13 +97,13 @@ public class ObjectService {
             body.substring(body.indexOf("expires") + 10, body.indexOf("tenant") - 3));
     }
 
-    private static final Pattern IMAGE_TAG_PATTERN = Pattern.compile( "!\\[[^\\]]+\\]\\(([^)]+)\\)");
+//    private static final Pattern IMAGE_TAG_PATTERN = Pattern.compile( "!\\[[^\\]]+\\]\\(([^)]+)\\)");
+    private Pattern IMAGE_TAG_PATTERN = Pattern.compile(  "!\\[.*?\\]\\((https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_ad016d3302b840af94a1946c5784d85a[^)]+)\\)");
     @Transactional
     public List<String> extractContentImage(String content){
 
 
         Matcher matcher = IMAGE_TAG_PATTERN.matcher(content);
-
         List<String> result = new ArrayList<>();
         while (matcher.find()) {
             String url = matcher.group(1);

--- a/src/main/java/peer/backend/service/file/ObjectService.java
+++ b/src/main/java/peer/backend/service/file/ObjectService.java
@@ -97,13 +97,12 @@ public class ObjectService {
             body.substring(body.indexOf("expires") + 10, body.indexOf("tenant") - 3));
     }
 
-//    private static final Pattern IMAGE_TAG_PATTERN = Pattern.compile( "!\\[[^\\]]+\\]\\(([^)]+)\\)");
-    private Pattern IMAGE_TAG_PATTERN = Pattern.compile(  "!\\[.*?\\]\\((https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_ad016d3302b840af94a1946c5784d85a[^)]+)\\)");
     @Transactional
     public List<String> extractContentImage(String content){
 
+        Pattern pattern = Pattern.compile(  "!\\[.*?\\]\\((" + storageUrl + "[^)]+)\\)");
 
-        Matcher matcher = IMAGE_TAG_PATTERN.matcher(content);
+        Matcher matcher = pattern.matcher(content);
         List<String> result = new ArrayList<>();
         while (matcher.find()) {
             String url = matcher.group(1);

--- a/src/main/java/peer/backend/service/file/ObjectService.java
+++ b/src/main/java/peer/backend/service/file/ObjectService.java
@@ -19,11 +19,16 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import peer.backend.exception.IllegalArgumentException;
 
+import javax.transaction.Transactional;
 import javax.validation.constraints.NotNull;
 import java.io.*;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Getter
@@ -90,6 +95,21 @@ public class ObjectService {
         this.tokenId = body.substring(body.indexOf("id") + 5, body.indexOf("expires") - 3);
         this.tokenExpireTime = OffsetDateTime.parse(
             body.substring(body.indexOf("expires") + 10, body.indexOf("tenant") - 3));
+    }
+
+    private static final Pattern IMAGE_TAG_PATTERN = Pattern.compile( "!\\[[^\\]]+\\]\\(([^)]+)\\)");
+    @Transactional
+    public List<String> extractContentImage(String content){
+
+
+        Matcher matcher = IMAGE_TAG_PATTERN.matcher(content);
+
+        List<String> result = new ArrayList<>();
+        while (matcher.find()) {
+            String url = matcher.group(1);
+            result.add(url);
+        }
+        return result;
     }
 
     private String getUrl(@NotNull String folderName, @NotNull String objectName) {


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
* ObjectController -> object storage 관리를 위해 filepath를 root/editor/userid로 변경
* ObjectService -> 마크다운 본문에서 image url을 추출하는 extractContentImage 메소드 추가
* recruit, post, showcase의 create, update, delete에 마크다운의 이미지를 엔티티로 생성, 삭제하는 로직 추가


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
