### PR TITLE
[Hotfix] add orphanRemoveal=true to RecruitTags

### DIFF
--- a/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -64,7 +64,7 @@ public class Recruit extends BaseEntity {
     private RecruitStatus status;
     @Column
     private String thumbnailUrl;
-    @OneToMany(mappedBy = "recruit", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "recruit", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecruitTag> recruitTags = new ArrayList<>();
     @Column
     private Long writerId;
@@ -80,10 +80,7 @@ public class Recruit extends BaseEntity {
         this.link = request.getLink();
         this.recruitTags.clear();
         if (request.getTagList() != null && !request.getTagList().isEmpty())
-        this.recruitTags = request.getTagList().stream()
-                .map(e -> (new RecruitTag(this.id, e)))
-                .collect(
-                        Collectors.toList());
+            addTags(request.getTagList());
         this.interviews.clear();
         if (request.getInterviewList() != null && !request.getInterviewList().isEmpty()) {
             for (RecruitInterviewDto interview : request.getInterviewList()) {
@@ -94,6 +91,14 @@ public class Recruit extends BaseEntity {
         if (urls != null && !urls.isEmpty()) {
             urls.forEach(this::addFile);
         }
+    }
+
+    private void addTag(Long tagId){
+        this.recruitTags.add(new RecruitTag(this.id, tagId));
+    }
+
+    private void addTags(List<Long> tags){
+        tags.forEach(this::addTag);
     }
 
     public void addInterview(RecruitInterviewDto interview) {


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
모집글 업데이트시 기존 태그가 삭제되지 않고 남아서 중복 생성되는 것을 방지하기 위해
Recruit 엔티티의 RecruitTags에 orphanRemoval=true 옵션 추가


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
