### PR TITLE
fix : temporary password problem

### DIFF
--- a/src/main/java/peer/backend/service/MemberService.java
+++ b/src/main/java/peer/backend/service/MemberService.java
@@ -106,7 +106,9 @@ public class MemberService {
     }
 
     public String getRandomPassword() {
-        final String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        final String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        final String chars_little = "abcdefghijklmnopqrstuvwxyz";
+        final String numbers = "0123456789";
 
         SecureRandom rm = new SecureRandom();
         StringBuilder sb = new StringBuilder();
@@ -115,14 +117,21 @@ public class MemberService {
             //무작위로 문자열의 인덱스 반환
             int index = rm.nextInt(chars.length());
             //index의 위치한 랜덤값
-            sb.append(chars.charAt(index));
+            if (i % 2 != 0)
+                sb.append(chars.charAt(index));
+            else
+                sb.append(chars_little.charAt(index));
         }
 
         int specialKey1 = Math.abs(rm.nextInt() % randomSpecialkeys.length());
         int specialKey2 = Math.abs(rm.nextInt() % randomSpecialkeys.length());
+        int specialKey3 = Math.abs(rm.nextInt() % numbers.length());
+        int specialKey4 = Math.abs(rm.nextInt() % numbers.length());
 
         sb.append(randomSpecialkeys.charAt(specialKey1));
+        sb.append(numbers.charAt(specialKey3));
         sb.append(randomSpecialkeys.charAt(specialKey2));
+        sb.append(numbers.charAt(specialKey4));
 
         return sb.toString();
     }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- 임시 비밀번호 발급 시 기존 비밀 번호 전략에서 랜덤한 문자열을 만들 때 영어 대문자, 소문자, 숫자를 한 줄로 세우고 랜덤하게 값을 도출함.
- 이때 확률적으로 숫자, 소문자, 대문자 중 하나라도 빠지면 비밀번호 변경 전략에 저촉되어 비밀번호 변경이 안됨.
- 이에 세가지 경우를 다 쪼개서 무조건, 3가지 타입 + 특수문자까지 다 들어갈 수 있도록 전략 수정함 


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
