### PR TITLE
[Hotfix] 1.0.2 adjust content size for creating recruit #807

### DIFF
--- a/src/main/java/peer/backend/dto/board/recruit/RecruitCreateRequest.java
+++ b/src/main/java/peer/backend/dto/board/recruit/RecruitCreateRequest.java
@@ -36,7 +36,7 @@ public class RecruitCreateRequest {
     private String place;
     @NotNull
     private String type;
-    @Size(min = 1, max = 1000, message = "")
+    @Size(min = 1, max = 20000, message = "")
     @NotNull
     @Lob
     private String content;


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
[변경 사항 모집글 생성시 본문 글자 제한을 20000(2만)자로 조정


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
