### PR TITLE
FEAT : add user attribute activated for checking is valid or not

### DIFF
--- a/src/main/java/peer/backend/dto/security/UserInfo.java
+++ b/src/main/java/peer/backend/dto/security/UserInfo.java
@@ -103,6 +103,7 @@ public class UserInfo {
             .messageAlarm(true)
             .nightAlarm(true)
             .teamAlarm(true)
+            .activated(true)
             .build();
     }
 }

--- a/src/main/java/peer/backend/entity/user/User.java
+++ b/src/main/java/peer/backend/entity/user/User.java
@@ -13,7 +13,6 @@ import lombok.Setter;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.core.Authentication;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 import peer.backend.entity.BaseEntity;
 import peer.backend.entity.board.recruit.Recruit;
@@ -44,6 +43,9 @@ public class User extends BaseEntity implements Login {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column
+    private Boolean activated = true;
 
     @Column(length = 100, unique = true, nullable = false)
     private String email;


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- User 객체에 `activated` 항목을 추가하였습니다. 해당 항목은 user 객체가 데모 내지는 유령 회원인 경우 등 검색이 안되어야 하며 메시지 검색 리스트 중에도 나타나면 안되기 때문입니다. 향후에는 검색 보안 부분에서 취약한 부분 개선을 해나갈 것입니다. 

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
