### PR TITLE
Fix message numbering failed and Add skill tag decoder 

### DIFF
--- a/src/main/java/peer/backend/controller/profile/ProfileController.java
+++ b/src/main/java/peer/backend/controller/profile/ProfileController.java
@@ -26,6 +26,7 @@ import peer.backend.service.profile.UserPortfolioService;
 import javax.persistence.LockModeType;
 import javax.validation.Valid;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -136,6 +137,12 @@ public class ProfileController {
         if (keyword.length() > 15 || keyword.length() < 2)
             return new ResponseEntity<>("검색 가능한 글자 수는 최소 2자부터 최대 15자까지 입니다.", HttpStatus.BAD_REQUEST);
 
+        // TODO ; skill tag searching keyword converter
+        try {
+            keyword = this.profileService.convertSearchingKeyword(keyword);
+        } catch ( UnsupportedEncodingException e) {
+            return new ResponseEntity<>(e, HttpStatus.BAD_REQUEST);
+        }
         List<SkillDTO> result = this.profileService.searchTagsWithKeyword(keyword);
         if (result.isEmpty())
             return new ResponseEntity<>("태그가 존재하지 않습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/peer/backend/service/message/MessageMainService.java
+++ b/src/main/java/peer/backend/service/message/MessageMainService.java
@@ -435,7 +435,7 @@ public class MessageMainService {
             MessageIndex firstLetter = MessageIndex.builder()
                     .user1(user)
                     .user2(target)
-                    .unreadMessageNumber1(1L)
+                    .unreadMessageNumber1(0L)
                     .unreadMessageNumber2(0L)
                     .userIdx1(user.getId())
                     .user1delete(false)

--- a/src/main/java/peer/backend/service/profile/ProfileService.java
+++ b/src/main/java/peer/backend/service/profile/ProfileService.java
@@ -27,6 +27,9 @@ import peer.backend.repository.user.UserSkillRepository;
 import peer.backend.service.file.ObjectService;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -241,5 +244,29 @@ public class ProfileService {
             skillList.add(hisSkil);
         };
         this.userSkillsRepository.saveAll(skillList);
+    }
+
+    public String convertSearchingKeyword(String keyword) throws UnsupportedEncodingException {
+        String result = "";
+        StringBuilder targetWord = new StringBuilder();
+
+        int firstPin;
+
+        for (int i = 0; i < keyword.length(); i++) {
+            if (keyword.charAt(i) == '%') {
+                firstPin = i;
+                targetWord.append('%');
+                while (keyword.charAt(i + 1) != '%') {
+                    targetWord.append(keyword.charAt(i));
+                    i++;
+                }
+                String encodedString = targetWord.toString();
+                String decodedString = URLDecoder.decode(encodedString, StandardCharsets.UTF_8);
+                keyword = keyword.replace(encodedString, decodedString);
+                i = firstPin + 1;
+            }
+        }
+        result = keyword;
+        return result;
     }
 }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- 메시지를 전달할 때 읽지 않은 경우 그 숫자를 표시해주는 기능을 넣었으나, 해당 기능이 프로필에서 보낼 때 정상적이지 않게 숫자가 카운팅됨.
- 이에 수정함 
---
- 스킬 태그 추가 수정으로 특수문자 변환되서 들어오는 값을 인코딩하여 수정하는 메소드 추가하여 테스트까지 마무리


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
