### PR TITLE
[Hotfix] 1.0.2 exclude image url from hitch content

### DIFF
--- a/src/main/java/peer/backend/dto/user/UserShowcaseResponse.java
+++ b/src/main/java/peer/backend/dto/user/UserShowcaseResponse.java
@@ -10,12 +10,14 @@ import java.util.List;
 @Getter
 @RequiredArgsConstructor
 public class UserShowcaseResponse {
+    private Long id;
     private String image;
     private String nickname;
     private String role;
 
     public UserShowcaseResponse(TeamUser teamUser){
         User user = teamUser.getUser();
+        this.id = user.getId();
         this.image = user.getImageUrl();
         this.nickname = user.getNickname();
         this.role = teamUser.getTeamUserJobs().get(0).getTeamJob().getName();

--- a/src/main/java/peer/backend/service/board/recruit/HitchHikingService.java
+++ b/src/main/java/peer/backend/service/board/recruit/HitchHikingService.java
@@ -17,6 +17,10 @@ import peer.backend.exception.OutOfRangeException;
 import peer.backend.repository.board.recruit.RecruitRepository;
 import peer.backend.service.TagService;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,6 +30,11 @@ public class HitchHikingService {
     private final RecruitRepository recruitRepository;
     private final TagService tagService;
 
+    private String excludeImageUrlFromContent(String origin){
+        String noTag = origin.replaceAll("!\\[.*?\\]\\(.*?\\)", "");
+        return noTag;
+
+    }
 
     @Transactional
     public Page<HitchListResponse> getHitchList(int page, int pageSize, String type, Long userId){
@@ -53,7 +62,7 @@ public class HitchHikingService {
         Recruit recruit = recruitRepository.findById(hitchId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 모집글입니다."));
         return HitchResponse.builder()
-                .content(recruit.getContent())
+                .content(excludeImageUrlFromContent(recruit.getContent()))
                 .memberImage(recruit.getTeam().getTeamUsers().stream().map(
                         teamUser -> teamUser.getUser().getImageUrl()).collect(Collectors.toList()))
                 .recruitmentQuota(recruit.getTeam().getMaxMember())

--- a/src/main/java/peer/backend/service/board/recruit/HitchHikingService.java
+++ b/src/main/java/peer/backend/service/board/recruit/HitchHikingService.java
@@ -31,9 +31,7 @@ public class HitchHikingService {
     private final TagService tagService;
 
     private String excludeImageUrlFromContent(String origin){
-        String noTag = origin.replaceAll("!\\[.*?\\]\\(.*?\\)", "");
-        return noTag;
-
+        return origin.replaceAll("!\\[.*?\\]\\(.*?\\)", "");
     }
 
     @Transactional

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -58,13 +58,17 @@ public class ShowcaseService {
                 .collect(Collectors.toList());
     }
 
+    private String excludeImageUrlFromContent(String origin){
+        return origin.replaceAll("!\\[.*?\\]\\(.*?\\)", "");
+    }
+
     private ShowcaseListResponse convertToDto(Post post, Authentication auth) {
         Team team = post.getBoard().getTeam();
         return ShowcaseListResponse.builder()
             .id(post.getId())
             .image(post.getImage())     // showcase에서 대표이미지는 항상 첫번째인덱스에 있습니다.
             .name(post.getBoard().getTeam().getName())
-            .description(post.getContent())
+            .description(excludeImageUrlFromContent(post.getContent()))
             .skill(
                 this.tagService.recruitTagListToTagResponseList(team.getRecruit().getRecruitTags()))
             .like(post.getLiked())


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
히치하이킹 리스트 반환시 content에서 이미지 태그를 제거합니다.
쇼케이스 리스트 반환시 content에서 이미지 태그를 제거합니다.
쇼케이스 반환시 member에 id 필드를 추가합니다.

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
