### PR TITLE
FIX: recruit validation check added

### DIFF
--- a/src/main/java/peer/backend/dto/team/TeamApplyDataDTO.java
+++ b/src/main/java/peer/backend/dto/team/TeamApplyDataDTO.java
@@ -1,0 +1,27 @@
+package peer.backend.dto.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TeamApplyDataDTO{
+    private Long teamJobId;
+    private String name;
+    private Integer max;
+    private Long teamId;
+    private Long pendingNumber;
+    private Long applyNumber;
+
+//    ava.lang.Long, java.lang.String, java.lang.Integer, java.lang.Long, int, int
+//    long, java.lang.String, int, long, long, long
+    public TeamApplyDataDTO(long teamJobId, String name, int max, long teamId, long pendingNumber, long applyNumber) {
+        this.teamJobId = teamJobId;
+        this.name = name;
+        this.max = max;
+        this.teamId = teamId;
+        this.pendingNumber = pendingNumber;
+        this.applyNumber = applyNumber;
+    }
+}

--- a/src/main/java/peer/backend/entity/board/recruit/Recruit.java
+++ b/src/main/java/peer/backend/entity/board/recruit/Recruit.java
@@ -53,6 +53,7 @@ public class Recruit extends BaseEntity {
 
     @Column
     private Long hit = 0L;
+
     @Column(nullable = false)
     @Size(max=100)
     private String title;

--- a/src/main/java/peer/backend/repository/team/TeamRepository.java
+++ b/src/main/java/peer/backend/repository/team/TeamRepository.java
@@ -1,10 +1,12 @@
 package peer.backend.repository.team;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import peer.backend.dto.team.TeamApplyDataDTO;
 import peer.backend.entity.team.Team;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
- recruit  관련하여 유효성 검사 추가함. 프론트 에서도 막았으나...
1) 모집글 상태 확인하여 완료 여부 판단하도록함 
2) 모집글 작성된 팀, 팀유저, 팀유저잡을 조인하여 전체 인원수, 확정된 멤버수, 대기중인 멤버수를 파악하여 에러 유효성 검사하는 부분 추가함 해당 부분 활용하면 복잡하지 않게 현재 팀의 상태 파악이 용이해짐 


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
