### PR TITLE
[Fix] : 모집글에서 홀로 남아있는 외로운 섬 하나 새들의 고향 #848

### DIFF
--- a/src/main/java/peer/backend/repository/team/TeamUserRepository.java
+++ b/src/main/java/peer/backend/repository/team/TeamUserRepository.java
@@ -27,7 +27,7 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 
     List<TeamUser> findByTeamIdAndStatus(Long teamId, TeamUserStatus status);
 
-    @Query("select count(t) > 0 from TeamUser t where t.teamId = :teamId and t.status = 'APPROVED'")
+    @Query("select count(t) > 1 from TeamUser t where t.teamId = :teamId and t.status = 'APPROVED'")
     Boolean existsApprovedByTeamId(Long teamId);
 
     Boolean existsByUserIdAndTeamIdAndStatus(Long userId, Long teamId, TeamUserStatus status);


### PR DESCRIPTION
물론이지 채

## 변경 사항
<!-- 변경 사항을 입력합니다. -->

생성한 본인은 팀 유저 상태가 Approved 기 때문에 본인만 남은 경우 삭제할 수가 없던 문제 수정.
나를 포함해서로 +1 로직 변경.

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
