### PR TITLE
[REFACTOR] 어드민 파트 짜잘 수정

### DIFF
--- a/src/main/java/peer/backend/controller/object/ObjectController.java
+++ b/src/main/java/peer/backend/controller/object/ObjectController.java
@@ -16,8 +16,10 @@ public class ObjectController {
 
     private final ObjectService objectService;
 
-    @PostMapping("/editor/image")
-    public String uploadImage(@RequestParam("image")MultipartFile image, Authentication auth) throws IOException {
-        return objectService.uploadImage(image, "editor/" + User.authenticationToUser(auth).getId());
+    @PostMapping({"/editor/image", "/admin/editor/image"})
+    public String uploadImage(@RequestParam("image") MultipartFile image, Authentication auth)
+        throws IOException {
+        return objectService.uploadImage(image,
+            "editor/" + User.authenticationToUser(auth).getId());
     }
 }

--- a/src/main/java/peer/backend/dto/announcement/AboutAnnouncementResponse.java
+++ b/src/main/java/peer/backend/dto/announcement/AboutAnnouncementResponse.java
@@ -15,8 +15,6 @@ public class AboutAnnouncementResponse {
 
     private String content;
 
-    private String image;
-
     private Long view;
 
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
@@ -29,7 +27,6 @@ public class AboutAnnouncementResponse {
         this.title = announcement.getTitle();
         this.writer = announcement.getWriter();
         this.content = announcement.getContent();
-        this.image = announcement.getImage();
         this.view = announcement.getView();
         this.createdAt = announcement.getCreatedAt();
         this.updatedAt = announcement.getUpdatedAt();

--- a/src/main/java/peer/backend/dto/announcement/AnnouncementListResponse.java
+++ b/src/main/java/peer/backend/dto/announcement/AnnouncementListResponse.java
@@ -10,12 +10,10 @@ public class AnnouncementListResponse {
     private final Long announcementId;
     private final AnnouncementStatus announcementStatus;
     private final String title;
-    private final String image;
 
     public AnnouncementListResponse(Announcement announcement) {
         this.announcementId = announcement.getId();
         this.announcementStatus = announcement.getAnnouncementStatus();
         this.title = announcement.getTitle();
-        this.image = announcement.getImage();
     }
 }

--- a/src/main/java/peer/backend/dto/announcement/AnnouncementResponse.java
+++ b/src/main/java/peer/backend/dto/announcement/AnnouncementResponse.java
@@ -13,7 +13,6 @@ public class AnnouncementResponse {
     private final String title;
     private final String writer;
     private final String content;
-    private final String image;
     private final Long view;
     private final AnnouncementStatus announcementStatus;
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
@@ -23,7 +22,6 @@ public class AnnouncementResponse {
         this.title = announcement.getTitle();
         this.writer = announcement.getWriter();
         this.content = announcement.getContent();
-        this.image = announcement.getImage();
         this.view = announcement.getView();
         this.announcementStatus = announcement.getAnnouncementStatus();
         if (this.announcementStatus.equals(AnnouncementStatus.RESERVATION)) {

--- a/src/main/java/peer/backend/dto/announcement/CreateAnnouncementRequest.java
+++ b/src/main/java/peer/backend/dto/announcement/CreateAnnouncementRequest.java
@@ -24,9 +24,6 @@ public class CreateAnnouncementRequest {
     @Size(max = 10000, message = "길이는 10000 이하여야합니다.")
     private String content;
 
-    @NotBlank(message = "이미지는 필수입니다.")
-    private String image;
-
     @ValidEnum(enumClass = AnnouncementNoticeStatus.class)
     private AnnouncementNoticeStatus announcementNoticeStatus;
 

--- a/src/main/java/peer/backend/dto/announcement/UpdateAnnouncementRequest.java
+++ b/src/main/java/peer/backend/dto/announcement/UpdateAnnouncementRequest.java
@@ -1,37 +1,10 @@
 package peer.backend.dto.announcement;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonFormat.Shape;
-import java.time.LocalDateTime;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import lombok.Getter;
-import peer.backend.annotation.ValidEnum;
-import peer.backend.entity.announcement.AnnouncementNoticeStatus;
 
 @Getter
-public class UpdateAnnouncementRequest {
-
-    @NotBlank(message = "제목은 필수입니다.")
-    @Size(max = 30, message = "길이는 30 이하여야합니다.")
-    private String title;
-
-    @NotBlank(message = "작성자는 필수입니다.")
-    @Size(max = 10, message = "길이는 10 이하여야합니다.")
-    private String writer;
-
-    @NotBlank(message = "내용은 필수입니다.")
-    @Size(max = 10000, message = "길이는 10000 이하여야합니다.")
-    private String content;
-
-    private String image;
-
-    @ValidEnum(enumClass = AnnouncementNoticeStatus.class)
-    private AnnouncementNoticeStatus announcementNoticeStatus;
-
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-    private LocalDateTime reservationDate;
+public class UpdateAnnouncementRequest extends CreateAnnouncementRequest {
 
     @NotNull(message = "공지사항 ID는 필수입니다.")
     private Long announcementId;

--- a/src/main/java/peer/backend/entity/announcement/Announcement.java
+++ b/src/main/java/peer/backend/entity/announcement/Announcement.java
@@ -42,9 +42,6 @@ public class Announcement extends BaseEntity {
     @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String image;
-
     @Column(nullable = false)
     private Long view;
 

--- a/src/main/java/peer/backend/service/AnnouncementService.java
+++ b/src/main/java/peer/backend/service/AnnouncementService.java
@@ -43,13 +43,13 @@ public class AnnouncementService {
 
         // 공지사항 글 관련 알림 전달
         this.notificationCreationService.makeNotificationForALL(
-                null,
-                request.getTitle() + "라는 공지사항이 올라왔습니다! 확인해주세요.",
-                "",
-                NotificationPriority.SCHEDULED,
-                NotificationType.SYSTEM,
-                request.getReservationDate(),
-                null
+            null,
+            request.getTitle() + "라는 공지사항이 올라왔습니다! 확인해주세요.",
+            "",
+            NotificationPriority.SCHEDULED,
+            NotificationType.SYSTEM,
+            request.getReservationDate(),
+            null
         );
     }
 
@@ -73,7 +73,6 @@ public class AnnouncementService {
     public void deleteAnnouncement(Long announcementId) {
         Announcement announcement = this.getAnnouncement(announcementId);
         this.announcementRepository.deleteById(announcementId);
-        this.objectService.deleteObject(announcement.getImage());
     }
 
     @Transactional
@@ -86,8 +85,6 @@ public class AnnouncementService {
 
     private Announcement createAnnouncementFromCreateAnnouncementRequest(
         CreateAnnouncementRequest request) {
-        String imageUrl = this.uploadAnnouncementImage(request.getImage());
-
         Announcement announcement = Announcement.builder()
             .title(request.getTitle())
             .writer(request.getWriter())
@@ -96,7 +93,6 @@ public class AnnouncementService {
                 this.getAnnouncementStatusFromAnnouncementNoticeStatus(
                     request.getAnnouncementNoticeStatus()))
             .announcementNoticeStatus(request.getAnnouncementNoticeStatus())
-            .image(imageUrl)
             .view(0L)
             .build();
 
@@ -144,11 +140,11 @@ public class AnnouncementService {
                 this.setAnnouncementReservationDate(announcement, request.getReservationDate());
             }
         }
-        if (Objects.nonNull(request.getImage())) {
-            this.objectService.deleteObject(announcement.getImage());
-            String imageUrl = this.uploadAnnouncementImage(request.getImage());
-            announcement.setImage(imageUrl);
-        }
+//        if (Objects.nonNull(request.getImage())) {
+//            this.objectService.deleteObject(announcement.getImage());
+//            String imageUrl = this.uploadAnnouncementImage(request.getImage());
+//            announcement.setImage(imageUrl);
+//        }
     }
 
     @Transactional


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
1. 토스트 에디터 이미지 업로드에 매핑 url을 추가하였습니다(어드민 공지사항에서 어드민 토큰으로도 API 사용이 가능하게끔)
2. 공지사항 쪽에 이미지 필드들 및 로직을 제거하였습니다.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
