### PR TITLE
[hotfix] add-authorId-to-PostCommentListResponse

### DIFF
--- a/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
@@ -22,6 +22,7 @@ public class PostCommentListResponse {
     private String createAt;
     @JsonProperty("isAuthor")
     private boolean isAuthor;
+    private Long authorId;
 
     public PostCommentListResponse(PostComment comment, User user){
         User author = comment.getUser();
@@ -31,5 +32,6 @@ public class PostCommentListResponse {
         this.content = comment.getContent();
         this.createAt = comment.getCreatedAt().toString();
         this.isAuthor = Objects.equals(author, user);
+        this.authorId = author.getId();
     }
 }

--- a/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
+++ b/src/main/java/peer/backend/dto/board/team/PostCommentListResponse.java
@@ -32,6 +32,6 @@ public class PostCommentListResponse {
         this.content = comment.getContent();
         this.createAt = comment.getCreatedAt().toString();
         this.isAuthor = Objects.equals(author, user);
-        this.authorId = author.getId();
+        this.authorId = (author == null) ? -1 : author.getId();
     }
 }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
게시물 댓글 조회시 authorId 필드를 추가합니다.
존재하지 않는 유저의 경우 authorId는 -1을 반환합니다.

시간이 없어 간단하게 추가할 수 있는 방식으로 작업되었습니다.
추후 hyeongki님이 작업하신 어노테이션으로 유저 유효성 검사가 수정될 필요가 있습니다.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
