### PR TITLE
Hotfix notification bugs

### DIFF
--- a/src/main/java/peer/backend/controller/board/RecruitController.java
+++ b/src/main/java/peer/backend/controller/board/RecruitController.java
@@ -16,6 +16,7 @@ import peer.backend.entity.board.recruit.enums.RecruitFavoriteEnum;
 import peer.backend.entity.user.User;
 import peer.backend.exception.BadRequestException;
 import peer.backend.service.board.recruit.RecruitService;
+import peer.backend.service.noti.NotificationCreationService;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.List;
 public class RecruitController {
 
     private final RecruitService recruitService;
+    private final NotificationCreationService notificationCreationService;
 
     @ApiOperation(value = "", notes = "모집게시글을 불러온다.")
     @GetMapping("/{recruit_id}")

--- a/src/main/java/peer/backend/controller/board/ShowcaseController.java
+++ b/src/main/java/peer/backend/controller/board/ShowcaseController.java
@@ -104,7 +104,7 @@ public class ShowcaseController {
                 BoardType.SHOWCASE);
         this.notificationCreationService.makeNotificationForTeam(
                 null,
-                user.getNickname() + "님께서 코멘트를 다셨습니다. : " + request.getContent(),
+                user.getNickname() + "님께서 댓글을 다셨습니다. : " + request.getContent(),
                 "/showcase/detail/" + request.getPostId(),
                 NotificationPriority.IMMEDIATE,
                 NotificationType.SYSTEM,

--- a/src/main/java/peer/backend/controller/board/ShowcaseController.java
+++ b/src/main/java/peer/backend/controller/board/ShowcaseController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import peer.backend.dto.board.team.*;
 import peer.backend.dto.noti.enums.NotificationPriority;
 import peer.backend.dto.noti.enums.NotificationType;
+import peer.backend.entity.board.team.Post;
 import peer.backend.entity.board.team.enums.BoardType;
 import peer.backend.entity.user.User;
 import peer.backend.service.board.team.BoardService;
@@ -94,22 +95,23 @@ public class ShowcaseController {
         }
     }
 
+    //TODO : DTO 수정 필요...!!
     @PostMapping("/comment")
     public void createShowcaseComment(@RequestBody @Valid PostCommentRequest request, Authentication auth){
         User user = User.authenticationToUser(auth);
-        boardService.createComment(
+        Post data = boardService.createComment(
                 request.getPostId(),
                 request.getContent(),
                 user,
                 BoardType.SHOWCASE);
         this.notificationCreationService.makeNotificationForTeam(
                 null,
-                user.getNickname() + "님께서 댓글을 다셨습니다. : " + request.getContent(),
+                user.getNickname() + "님께서 "+ data.getTitle() +" 에 댓글을 다셨습니다 : " + request.getContent(),
                 "/showcase/detail/" + request.getPostId(),
                 NotificationPriority.IMMEDIATE,
                 NotificationType.SYSTEM,
                 null,
-                request.getTeamId(),
+                data.getOwnTeamId(),
                 null
         );
     }

--- a/src/main/java/peer/backend/repository/team/TeamUserRepository.java
+++ b/src/main/java/peer/backend/repository/team/TeamUserRepository.java
@@ -41,6 +41,6 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
     @Query("SELECT m.userId FROM TeamUser m WHERE m.teamId IN :teamId AND m.user.activated = true")
     List<Long> findAllUserIdsIn(@Param("teamId") List<Long> teamId);
 
-    @Query("SELECT m.userId FROM TeamUser m WHERE m.teamId = :teamId AND m.user.activated = true")
+    @Query("SELECT m.userId FROM TeamUser m WHERE m.teamId = :teamId AND m.status = 'APPROVED'")
     List<Long> findUserIdsIn(@Param("teamId") Long teamId);
 }

--- a/src/main/java/peer/backend/repository/user/UserRepository.java
+++ b/src/main/java/peer/backend/repository/user/UserRepository.java
@@ -40,22 +40,27 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT CASE WHEN COUNT(n) > 0 THEN true ELSE false END FROM User n WHERE n.nickname = :nickname")
     Boolean existsByNickname(String nickname);
 
+    @Modifying
     @Query("UPDATE User m SET m.alarmCounter = m.alarmCounter + 1")
     void increaseAlarmCountForALL();
 
+    @Modifying
     @Query("UPDATE User m SET m.alarmCounter = CASE WHEN (m.alarmCounter - 1) < 0 then 0 ELSE (m.alarmCounter - 1) END")
     void decreaseAlarmCountForALL();
 
-    @Query("UPDATE User m SET m.alarmCounter = m.alarmCounter + 1 WHERE m.id IN : userIds AND m.activated = true")
+    @Modifying
+    @Query("UPDATE User m SET m.alarmCounter = m.alarmCounter + 1, m.newAlarmCounter = m.newAlarmCounter + 1 WHERE m.id IN :userIds AND m.activated = true")
     void increaseAlarmCountForUsers(@Param("userIds") List<Long> userIds);
 
     @Modifying
     @Query("UPDATE User m SET m.alarmCounter = m.alarmCounter + 1, m.newAlarmCounter = m.newAlarmCounter + 1 WHERE m.id = :userId AND m.activated = true")
     void increaseAlarmCountForOne(@Param("userId") Long userId);
 
+    @Modifying
     @Query("UPDATE User m SET m.alarmCounter = CASE WHEN (m.alarmCounter - 1) < 0 then 0 ELSE (m.alarmCounter - 1) END WHERE m.id IN :userIds")
     void decreaseAlarmCountForUsers(@Param("userIds") List<Long> userIds);
 
+    @Modifying
     @Query("UPDATE User m SET m.alarmCounter = CASE WHEN (m.alarmCounter - 1) < 0 then 0 ELSE (m.alarmCounter - 1) END WHERE m.id = :userId")
     void decreaseAlarmCountForOne(@Param("userId") Long userId);
 

--- a/src/main/java/peer/backend/service/board/recruit/RecruitService.java
+++ b/src/main/java/peer/backend/service/board/recruit/RecruitService.java
@@ -88,6 +88,9 @@ public class RecruitService {
     private final EntityManager entityManager;
     private final NotificationCreationService notificationCreationService;
 
+    private static final String teamPage = "/teams/";
+    private static final String teamList = "/team-list";
+
     //query 생성 및 주입
     @PersistenceContext
     private EntityManager em;
@@ -451,6 +454,30 @@ public class RecruitService {
                 .status(TeamUserStatus.PENDING)
                 .answers(request.getAnswerList())
                 .build());
+
+        // 신청자를 위한 알림
+        this.notificationCreationService.makeNotificationForUser(
+                null,
+                "축하드립니다! " + team.getName()
+                        + " 팀에 신청을 완료하였습니다. 답변이 올 때까지 기다려볼까요? 궁금한 것은 팀장에게 메시지를 날려보아도 좋습니다!",
+                teamList,
+                NotificationPriority.IMMEDIATE,
+                NotificationType.SYSTEM,
+                null,
+                user.getId(),
+                null
+        );
+
+        this.notificationCreationService.makeNotificationForTeam(
+                null,
+                team.getName() + " 팀에 새로운 동료가 접수되었습니다! 확인 하러 가시죠!",
+                teamPage + team.getId(),
+                NotificationPriority.IMMEDIATE,
+                NotificationType.SYSTEM,
+                null,
+                team.getId(),
+                null
+        );
     }
 
     @Transactional

--- a/src/main/java/peer/backend/service/board/team/ShowcaseService.java
+++ b/src/main/java/peer/backend/service/board/team/ShowcaseService.java
@@ -125,7 +125,7 @@ public class ShowcaseService {
             // 관심리스트에 추가 됨을 알림
             this.notificationCreationService.makeNotificationForTeam(
                 null,
-                showcase.getTitle() + " 쇼케이스가 누군가의 관심리스트에 등록되었습니다!",
+                showcase.getTitle() + "  가 누군가의 관심리스트에 등록되었습니다!",
                 detailPage + showcase.getId(),
                 NotificationPriority.IMMEDIATE,
                 NotificationType.SYSTEM,
@@ -145,9 +145,13 @@ public class ShowcaseService {
             .orElseThrow(() -> new NotFoundException("존재하지 않는 모집글입니다."));
         Optional<PostLike> postLike = postLikeRepository.findById(
             new PostLikePK(user.getId(), showcaseId, PostLikeType.LIKE));
+
+        boolean likeOrHate;
+
         if (postLike.isPresent()) {
             postLikeRepository.delete(postLike.get());
             showcase.decreaseLike();
+            likeOrHate = false;
         } else {
             PostLike newFavorite = new PostLike();
             newFavorite.setUser(user);
@@ -157,18 +161,21 @@ public class ShowcaseService {
             newFavorite.setType(PostLikeType.LIKE);
             postLikeRepository.save(newFavorite);
             showcase.increaseLike();
+            likeOrHate = true;
         }
 
-        this.notificationCreationService.makeNotificationForTeam(
-            null,
-            showcase.getTitle() + " 쇼케이스가 좋아요를 받았습니다! 확인해보시겠어요?",
-            detailPage + showcase.getId(),
-            NotificationPriority.IMMEDIATE,
-            NotificationType.SYSTEM,
-            null,
-            showcase.getOwnTeamId(),
-            null
-        );
+        if (likeOrHate) {
+            this.notificationCreationService.makeNotificationForTeam(
+                null,
+                showcase.getTitle() + " 가 좋아요를 받았습니다! 확인해보시겠어요?",
+                detailPage + showcase.getId(),
+                NotificationPriority.IMMEDIATE,
+                NotificationType.SYSTEM,
+                null,
+                showcase.getOwnTeamId(),
+                null
+            );
+        }
 
         return showcase.getLiked();
     }
@@ -259,7 +266,7 @@ public class ShowcaseService {
 
         this.notificationCreationService.makeNotificationForTeam(
             null,
-            post.getTitle() + " 쇼케이스가 등록 되었습니다! 한 번 확인하러 가볼까요?",
+            post.getTitle() + " 가 등록 되었습니다! 한 번 확인하러 가볼까요?",
             detailPage + post.getId(),
             NotificationPriority.IMMEDIATE,
             NotificationType.SYSTEM,

--- a/src/main/java/peer/backend/service/noti/NotificationCreationService.java
+++ b/src/main/java/peer/backend/service/noti/NotificationCreationService.java
@@ -272,6 +272,9 @@ public class NotificationCreationService {
                                         @NotNull Long teamId,
                                         @Nullable String imageLink)  {
         List<Long> targetUsers = this.makeUserListFromTeamId(teamId);
+
+        targetUsers.forEach(m-> System.out.println("나오나? : " + m.toString()));
+
         this.makeNotificationForUserList(
                 title,
                 body,

--- a/src/main/java/peer/backend/service/team/TeamService.java
+++ b/src/main/java/peer/backend/service/team/TeamService.java
@@ -185,8 +185,8 @@ public class TeamService {
 
         this.notificationCreationService.makeNotificationForTeam(
             null,
-            "팀 설정이 변경되었습니다. 확인 부탁드립니다.",
-            teamPage + teamId,
+            team.getName() + " 팀 상태가 변경되었습니다. 확인 해볼까요? 자세한 내용은 리더들에게 확인해보세요.",
+            teamList,
             NotificationPriority.IMMEDIATE,
             NotificationType.TEAM,
             null,
@@ -339,36 +339,6 @@ public class TeamService {
                 .image(applicantUser.getImageUrl())
                 .build());
         }
-
-//        // 신청자를 위한 알림
-//        this.notificationCreationService.makeNotificationForUser(
-//            null,
-//            "축하드립니다! " + team.getName()
-//                + " 팀에 신청을 완료하였습니다. 답변이 올 때까지 기다려볼까요? 궁금한 것은 팀장에게 메시지를 날려보아도 좋습니다!",
-//            teamList,
-//            NotificationPriority.IMMEDIATE,
-//            NotificationType.SYSTEM,
-//            null,
-//            user.getId(),
-//            null
-//        );
-
-//        //팀리더에게 알림
-//        List<TeamUser> owner = team.getTeamUsers().stream()
-//            .filter(m -> m.getRole().equals(TeamUserRoleType.LEADER)).collect(Collectors.toList());
-//        List<Long> userIds = new ArrayList<>();
-//        owner.forEach(m -> userIds.add(m.getUserId()));
-//        this.notificationCreationService.makeNotificationForUserList(
-//            null,
-//            team.getName() + " 팀에 새로운 동료 신청이 들어왔습니다! 어떤 분인지 맞이하러 가볼까요?",
-//            teamPage + team.getId() + "/setting",
-//            NotificationPriority.IMMEDIATE,
-//            NotificationType.TEAM,
-//            null,
-//            userIds,
-//            team.getTeamLogoPath()
-//        );
-
         return result;
     }
 
@@ -698,7 +668,7 @@ public class TeamService {
 
         this.notificationCreationService.makeNotificationForTeam(
             null,
-            team.getName() + " 팀이 해산되었슴을 알립니다.",
+            team.getName() + " 팀이 해산되었습니다.",
             teamList,
             NotificationPriority.IMMEDIATE,
             NotificationType.SYSTEM,

--- a/src/main/java/peer/backend/service/team/TeamService.java
+++ b/src/main/java/peer/backend/service/team/TeamService.java
@@ -340,34 +340,34 @@ public class TeamService {
                 .build());
         }
 
-        // 신청자를 위한 알림
-        this.notificationCreationService.makeNotificationForUser(
-            null,
-            "축하드립니다! " + team.getName()
-                + " 팀에 신청을 완료하였습니다. 답변이 올 때까지 기다려볼까요? 궁금한 것은 팀장에게 메시지를 날려보아도 좋습니다!",
-            teamList,
-            NotificationPriority.IMMEDIATE,
-            NotificationType.SYSTEM,
-            null,
-            user.getId(),
-            null
-        );
+//        // 신청자를 위한 알림
+//        this.notificationCreationService.makeNotificationForUser(
+//            null,
+//            "축하드립니다! " + team.getName()
+//                + " 팀에 신청을 완료하였습니다. 답변이 올 때까지 기다려볼까요? 궁금한 것은 팀장에게 메시지를 날려보아도 좋습니다!",
+//            teamList,
+//            NotificationPriority.IMMEDIATE,
+//            NotificationType.SYSTEM,
+//            null,
+//            user.getId(),
+//            null
+//        );
 
-        //팀리더에게 알림
-        List<TeamUser> owner = team.getTeamUsers().stream()
-            .filter(m -> m.getRole().equals(TeamUserRoleType.LEADER)).collect(Collectors.toList());
-        List<Long> userIds = new ArrayList<>();
-        owner.forEach(m -> userIds.add(m.getUserId()));
-        this.notificationCreationService.makeNotificationForUserList(
-            null,
-            team.getName() + " 팀에 새로운 동료 신청이 들어왔습니다! 어떤 분인지 맞이하러 가볼까요?",
-            teamPage + team.getId() + "/setting",
-            NotificationPriority.IMMEDIATE,
-            NotificationType.TEAM,
-            null,
-            userIds,
-            team.getTeamLogoPath()
-        );
+//        //팀리더에게 알림
+//        List<TeamUser> owner = team.getTeamUsers().stream()
+//            .filter(m -> m.getRole().equals(TeamUserRoleType.LEADER)).collect(Collectors.toList());
+//        List<Long> userIds = new ArrayList<>();
+//        owner.forEach(m -> userIds.add(m.getUserId()));
+//        this.notificationCreationService.makeNotificationForUserList(
+//            null,
+//            team.getName() + " 팀에 새로운 동료 신청이 들어왔습니다! 어떤 분인지 맞이하러 가볼까요?",
+//            teamPage + team.getId() + "/setting",
+//            NotificationPriority.IMMEDIATE,
+//            NotificationType.TEAM,
+//            null,
+//            userIds,
+//            team.getTeamLogoPath()
+//        );
 
         return result;
     }
@@ -392,7 +392,7 @@ public class TeamService {
             NotificationPriority.IMMEDIATE,
             NotificationType.SYSTEM,
             null,
-            user.getId(),
+            teamUserJob.getTeamUser().getUser().getId(),
             null
         );
         this.notificationCreationService.makeNotificationForTeam(
@@ -424,12 +424,12 @@ public class TeamService {
         // 신청자에게 알림 보냄
         this.notificationCreationService.makeNotificationForUser(
             null,
-            "안타깝게도 지원이 거절 당했습니다. 팀 페이지에서 자세한 내용을 확인해주세요.",
+            "안타깝게도 " + teamUser.getTeam().getName() +" 팀에 대한 지원이 거절 당했습니다. 팀 페이지에서 자세한 내용을 확인해주세요.",
             teamList,
             NotificationPriority.IMMEDIATE,
             NotificationType.SYSTEM,
             null,
-            user.getId(),
+            teamUser.getUserId(),
             null
         );
     }

--- a/src/main/java/peer/backend/service/team/TeamService.java
+++ b/src/main/java/peer/backend/service/team/TeamService.java
@@ -384,6 +384,8 @@ public class TeamService {
         Team team = this.teamRepository.findById(teamId).orElseThrow(
             () -> new NotFoundException("존재하지 않는 팀입니다.")
         );
+
+        Long targetId =  teamUserJob.getTeamUser().getUser().getId();
         // 신청자에게 알리기
         this.notificationCreationService.makeNotificationForUser(
             null,
@@ -392,17 +394,28 @@ public class TeamService {
             NotificationPriority.IMMEDIATE,
             NotificationType.SYSTEM,
             null,
-            teamUserJob.getTeamUser().getUser().getId(),
+            targetId,
             null
         );
-        this.notificationCreationService.makeNotificationForTeam(
-            null,
+
+        List<Long> userIds = new ArrayList<>();
+        team.getTeamUsers().forEach(m -> {
+                    if (m.getStatus().equals(TeamUserStatus.APPROVED)) {
+                        if (!m.getUserId().equals(targetId)){
+                            userIds.add(m.getUserId());
+                        }
+                    }
+                }
+        );
+
+        this.notificationCreationService.makeNotificationForUserList(
+                null,
             "여러분 새로운 동료가 찾아왔습니다. 모두 축하해주세요!",
             teamPage + teamId,
             NotificationPriority.IMMEDIATE,
             NotificationType.TEAM,
             null,
-            teamId,
+            userIds,
             team.getTeamLogoPath()
         );
     }


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
### 주요 문제 포인트. 
1. 팀 쪽 권한 및 상태에 따라 알림이 전달되어야 하는데, 그렇게 되지 못한 점 발견
2. 쇼케이스 쪽 DTO 잘못되어 있으나, 그것을 수정하지 않은체 진행한 것 발견함.팀ID가 전달되지 않아, 대상이 비정상적으로 되어 알림 이벤트가 뜨지 않는 문제 발견
3. 멘트가 중의적이거나 일관적이지 않은 문제들 

### 주요 해결 리스트
- 알림 쪽 DB에 필요한 값들 수정하는 JPQL에 @Modifying 어노테이션 추가 
- 쪽지 전달 관련 알림 전체 수정
- 회원가입 시 나오는 문구 수정
- 팀 전반 알림 위치, 알림 관련 로직 수정 / 팀원 탐색 메소드에 대해 팀 상태 조건 추가 
- 모집글, 쇼케이스 쪽 관련 댓글, 좋아요 등에서 로직에 맞춰 알림이 갈 수 있도록 수정함. 

<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
- 전체 테스트 사이트를 통해 직접 진행하여 작동여부 파악 완료 