### PR TITLE
feat:add-getJob-getJobList

### DIFF
--- a/src/main/java/peer/backend/config/SecurityConfig.java
+++ b/src/main/java/peer/backend/config/SecurityConfig.java
@@ -91,6 +91,8 @@ public class SecurityConfig {
             .antMatchers(HttpMethod.GET, "/api/v1/showcase/*", "/api/v1/showcase",
                 "/api/v1/showcase/comment/*")
             .permitAll()
+            .antMatchers(HttpMethod.GET, "/api/v1/job/*", "/api/v1/job")
+            .permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/profile/other")
             .permitAll()
             .antMatchers(HttpMethod.GET, "/socket.io/**")

--- a/src/main/java/peer/backend/controller/board/JobController.java
+++ b/src/main/java/peer/backend/controller/board/JobController.java
@@ -1,0 +1,27 @@
+package peer.backend.controller.board;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+import peer.backend.dto.board.Job.JobListResponse;
+import peer.backend.dto.board.Job.JobResponse;
+import peer.backend.service.board.Job.JobService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/job")
+@Slf4j
+public class JobController {
+
+    private final JobService jobService;
+    @GetMapping("")
+    public Page<JobListResponse> getJobList(@RequestParam int page, @RequestParam int pageSize){
+       return jobService.getJobList(page, pageSize);
+    }
+
+    @GetMapping("/{jobId}")
+    public JobResponse getJob(@PathVariable Long jobId){
+        return jobService.getJob(jobId);
+    }
+}

--- a/src/main/java/peer/backend/dto/board/Job/JobListResponse.java
+++ b/src/main/java/peer/backend/dto/board/Job/JobListResponse.java
@@ -1,0 +1,17 @@
+package peer.backend.dto.board.Job;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JobListResponse {
+    String title;
+    String createdAt;
+    String writerName;
+    Long id;
+}

--- a/src/main/java/peer/backend/dto/board/Job/JobResponse.java
+++ b/src/main/java/peer/backend/dto/board/Job/JobResponse.java
@@ -1,0 +1,19 @@
+package peer.backend.dto.board.Job;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import javax.swing.border.TitledBorder;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class JobResponse {
+    String title;
+    String writerName;
+    String createdAt;
+    String content;
+    Long id;
+}

--- a/src/main/java/peer/backend/entity/board/team/enums/BoardType.java
+++ b/src/main/java/peer/backend/entity/board/team/enums/BoardType.java
@@ -11,7 +11,8 @@ public enum BoardType {
     NORMAL("NORMAL"),
     ADMIN("ADMIN"),
     SHOWCASE("SHOWCASE"),
-    NOTICE("NOTICE")
+    NOTICE("NOTICE"),
+    JOB("JOB")
     ;
     private final String type;
 

--- a/src/main/java/peer/backend/repository/board/team/PostRepository.java
+++ b/src/main/java/peer/backend/repository/board/team/PostRepository.java
@@ -23,4 +23,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p JOIN p.postLike pl JOIN p.board b WHERE pl.userId = :userId AND pl.type = :type AND p.isPublic = :isPublic AND b.type = :boardType")
     Page<Post> findShowcaseFavoriteList(boolean isPublic, BoardType boardType, Long userId, PostLikeType type, Pageable pageable);
+
+    Page<Post> findAllByBoardType(BoardType type, Pageable pageable);
 }

--- a/src/main/java/peer/backend/service/board/Job/JobService.java
+++ b/src/main/java/peer/backend/service/board/Job/JobService.java
@@ -1,0 +1,42 @@
+package peer.backend.service.board.Job;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import peer.backend.dto.board.Job.JobListResponse;
+import peer.backend.dto.board.Job.JobResponse;
+import peer.backend.entity.board.team.Post;
+import peer.backend.entity.board.team.enums.BoardType;
+import peer.backend.exception.NotFoundException;
+import peer.backend.repository.board.team.PostRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JobService {
+
+    private final PostRepository postRepository;
+    public Page<JobListResponse> getJobList(int page, int pageSize){
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
+        Page<Post> result = postRepository.findAllByBoardType(BoardType.JOB, pageable);
+
+        return result.map(post ->
+                new JobListResponse(post.getTitle(),
+                        post.getCreatedAt().toString(),
+                        post.getUser().getNickname(),
+                        post.getId()));
+    }
+
+    public JobResponse getJob(Long jobId){
+        Post job = postRepository.findById(jobId)
+                .orElseThrow(() -> new NotFoundException("Not Found"));
+        return new JobResponse(job.getTitle(),
+                job.getUser().getNickname(),
+                job.getContent(),
+                job.getCreatedAt().toString(),
+                job.getId());
+    }
+}


### PR DESCRIPTION
## 변경 사항
<!-- 변경 사항을 입력합니다. -->
채용공고를 위한 getJob, getJobList 두가지 api를 구현
* controller, service, dto 추가
* BoardType enum에 job type 추가
* PostRepository에 boardtype으로 페이지네이션 추가
* security config의 필터체인에 해당 api의 GET Method를 전체 공개로 설정

* 해당 기능은 admin에서 채용공고를 올리고 내리는 기능이 없이 수동으로 게시물을 작성하도록 하였음.
* 따라서 추후 admin 기능으로 개발이 필요함.


<br><br><br>
## 테스트 결과
<!-- 테스트 결과를 입력홥니다. -->
